### PR TITLE
[feat] 로그인 페이지 MSW & API 적용 (#29)

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
       if (typeof window !== "undefined") {
         localStorage.setItem(ACCESS_TOKEN_KEY, access_token);
       }
-      router.push("/mypage");
+      router.push("/");
     } catch (err) {
       const axiosError = err as AxiosError<{ message?: string }>;
       const message =

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,14 @@
+export async function register() {
+  if (
+    process.env.NEXT_RUNTIME === "nodejs" &&
+    process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
+  ) {
+    const { server } = await import("./src/mocks/server");
+
+    server.listen({
+      onUnhandledRequest: "bypass",
+    });
+
+    console.log("✓ MSW Server Mocking Enabled");
+  }
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -22,7 +22,7 @@ export async function login(
   password: string
 ): Promise<LoginSuccessResponse> {
   const { data } = await apiClient.post<LoginSuccessResponse>(
-    "/api/v1/auth/login",
+    "/api/v1/auth/login/",
     { email, password }
   );
   return data;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,7 @@
 import axios from "axios";
 
-const baseURL =
-  process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
-    ? ""
-    : process.env.NEXT_PUBLIC_API_BASE_URL || "";
+// 항상 실제 API URL 사용. MSW는 핸들러가 있는 엔드포인트만 mock, 나머지는 bypass
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
 export const apiClient = axios.create({
   baseURL,

--- a/src/mocks/data/auth.ts
+++ b/src/mocks/data/auth.ts
@@ -1,0 +1,13 @@
+/** 로그인 Mock 사용자 (MSW 개발용) */
+export const mockUsers = [
+  {
+    email: "user@example.com",
+    password: "password123",
+    access_token: "mock-access-token-user",
+  },
+  {
+    email: "test@test.com",
+    password: "test1234",
+    access_token: "mock-access-token-test",
+  },
+] as const;

--- a/src/mocks/data/index.ts
+++ b/src/mocks/data/index.ts
@@ -1,3 +1,4 @@
 export * from "./games";
 export * from "./user";
 export * from "./preferences";
+export * from "./auth";

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,4 @@
-import { delay, http, HttpResponse } from "msw";
+import { http, HttpResponse } from "msw";
 import { userPreferences } from "../data/user";
 
 // MSW 메모리 store - 취향 수정 시 여기에 저장됨
@@ -8,33 +8,10 @@ const preferencesStore = {
   tags: [...userPreferences.tags],
 };
 
+// 로그인은 핸들러 없음 → 실제 API로 bypass (onUnhandledRequest: 'bypass')
 export const handlers = [
-  http.all("*", async () => {
-    await delay(300);
-  }),
   http.get("/api/health", () => {
     return HttpResponse.json({ ok: true });
-  }),
-  http.post("/api/v1/auth/login", async ({ request }) => {
-    const body = (await request.json()) as {
-      email?: string;
-      password?: string;
-    };
-    if (!body.email || !body.password) {
-      return HttpResponse.json(
-        {
-          status_code: "401",
-          code: "INVALID_CREDENTIALS",
-          message: "이메일 또는 비밀번호가 올바르지 않습니다.",
-        },
-        { status: 401 }
-      );
-    }
-    return HttpResponse.json({
-      access_token: "mock-access-token",
-      token_type: "bearer",
-      expires_in: 3600,
-    });
   }),
 
   // 게임 취향 조회

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);


### PR DESCRIPTION
## 🩵 PR 요약
- 로그인 실제 API 연동 및 MSW selective mock 적용, MSW 서버 사이드 instrumentation 설정

## 📌 관련 이슈
Closes #29

## 📄 상세 내용
- [x] 로그인 Mock 사용자 데이터 추가 (`src/mocks/data/auth.ts`)
- [x] 로그인 실제 API 연동 (`apiClient` 항상 `NEXT_PUBLIC_API_BASE_URL` 사용, 엔드포인트 `/api/v1/auth/login/` 적용)
- [x] MSW selective mock: 로그인 핸들러 제거 → 실제 API 호출
- [x] MSW 서버 사이드 설정 (`instrumentation.ts`, `src/mocks/server.ts`, `onUnhandledRequest: 'bypass'`)

## 💬 리뷰 포인트
- `NEXT_PUBLIC_API_MOCKING=enabled`일 때 로그인만 실제 API, 나머지는 MSW mock으로 동작하는 구조 검토
- `instrumentation.ts`의 Node.js 런타임 분기 및 MSW 서버 초기화 로직 검토

## 📸 스크린샷 (선택)
<!-- UI 변경 없음 -->

## 🧠 기타 참고사항
- `.env`에 `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_API_MOCKING=enabled` 필요
- 로그인은 백엔드 실제 API(`NEXT_PUBLIC_API_BASE_URL`) 호출, 취향·health 등은 MSW mock 사용

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료