### PR TITLE
[feat] 탭/창 닫으면 로그아웃 (localStorage → sessionStorage) (#41)

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -19,7 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { Icon3D } from "./Icon3D";
-import { logout, ACCESS_TOKEN_KEY } from "@/src/api/auth";
+import { logout, getAccessToken, removeAccessToken } from "@/src/api/auth";
 import { fetchUserProfile } from "@/src/api/mypage";
 import type { UserProfile } from "@/src/api/mypage";
 import { headerSearchGames } from "@/src/mocks/data/games";
@@ -47,13 +47,13 @@ export function Header() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    // 개발 시 ?logout=1 쿼리로 로그아웃 상태 강제 (localStorage 정리)
+    // 개발 시 ?logout=1 쿼리로 로그아웃 상태 강제 (토큰 정리)
     const params = new URLSearchParams(window.location.search);
     if (params.get("logout") === "1") {
-      localStorage.removeItem(ACCESS_TOKEN_KEY);
+      removeAccessToken();
       window.history.replaceState({}, "", window.location.pathname);
     }
-    const hasToken = !!localStorage.getItem(ACCESS_TOKEN_KEY);
+    const hasToken = !!getAccessToken();
     queueMicrotask(() => setIsLoggedIn(hasToken));
   }, [pathname]);
 
@@ -87,17 +87,13 @@ export function Header() {
   }, []);
 
   const handleLogout = async () => {
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem(ACCESS_TOKEN_KEY)
-        : null;
+    const token = getAccessToken();
     try {
       if (token) await logout(token);
     } catch {
       // API 실패해도 로컬 로그아웃 진행
     } finally {
-      if (typeof window !== "undefined")
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
+      removeAccessToken();
       setIsLoggedIn(false);
       setShowProfileMenu(false);
       router.push("/");

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { AuthBackground } from "@/app/components/common/AuthBackground";
 import { LoginLogo } from "@/app/components/login/LoginLogo";
 import { LoginForm } from "@/app/components/login/LoginForm";
-import { login, ACCESS_TOKEN_KEY } from "@/src/api/auth";
+import { login, setAccessToken } from "@/src/api/auth";
 import { AxiosError } from "axios";
 import styles from "./page.module.scss";
 
@@ -23,9 +23,7 @@ export default function LoginPage() {
 
     try {
       const { access_token } = await login(email, password);
-      if (typeof window !== "undefined") {
-        localStorage.setItem(ACCESS_TOKEN_KEY, access_token);
-      }
+      setAccessToken(access_token);
       router.push("/");
     } catch (err) {
       const axiosError = err as AxiosError<{ message?: string }>;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,12 @@
 import { authApiClient } from "@/src/lib/api";
-import { ACCESS_TOKEN_KEY } from "@/src/constants/auth";
+import {
+  ACCESS_TOKEN_KEY,
+  getAccessToken,
+  removeAccessToken,
+  setAccessToken,
+} from "@/src/constants/auth";
 
-export { ACCESS_TOKEN_KEY };
+export { ACCESS_TOKEN_KEY, getAccessToken, removeAccessToken, setAccessToken };
 
 export interface LoginRequest {
   email: string;

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,1 +1,17 @@
 export const ACCESS_TOKEN_KEY = "access_token";
+
+// 탭/창 닫으면 로그아웃 (sessionStorage 사용)
+export const getAccessToken = (): string | null =>
+  typeof window !== "undefined"
+    ? sessionStorage.getItem(ACCESS_TOKEN_KEY)
+    : null;
+
+export const setAccessToken = (token: string): void => {
+  if (typeof window !== "undefined")
+    sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+};
+
+export const removeAccessToken = (): void => {
+  if (typeof window !== "undefined")
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,7 +7,11 @@ const apiBaseURL =
     ? ""
     : process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
-import { ACCESS_TOKEN_KEY } from "@/src/constants/auth";
+import {
+  getAccessToken,
+  removeAccessToken,
+  setAccessToken,
+} from "@/src/constants/auth";
 
 export const apiClient = axios.create({
   baseURL: apiBaseURL,
@@ -18,11 +22,9 @@ export const apiClient = axios.create({
 
 // 요청 시 토큰 첨부
 apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-  if (typeof window !== "undefined") {
-    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+  const token = getAccessToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
@@ -39,15 +41,11 @@ apiClient.interceptors.response.use(
       try {
         const { refreshToken } = await import("@/src/api/auth");
         const { access_token } = await refreshToken();
-        if (typeof window !== "undefined") {
-          localStorage.setItem(ACCESS_TOKEN_KEY, access_token);
-        }
+        setAccessToken(access_token);
         originalConfig.headers.Authorization = `Bearer ${access_token}`;
         return apiClient(originalConfig);
       } catch (refreshErr) {
-        if (typeof window !== "undefined") {
-          localStorage.removeItem(ACCESS_TOKEN_KEY);
-        }
+        removeAccessToken();
         return Promise.reject(refreshErr);
       }
     }


### PR DESCRIPTION
## 🩵PR 요약
토큰 저장소를 localStorage에서 sessionStorage로 변경하고, 토큰 조회/설정/삭제용 헬퍼 함수를 추가했습니다.

## 📌 관련 이슈
Closes #41 

## 📄 상세 내용
- [x] sessionStorage 기반 토큰 헬퍼 함수 추가
- [x] 로그인/Header/API 클라이언트에서 토큰 헬퍼 사용으로 변경
- [x] 탭을 닫으면 토큰이 삭제되어 자동 로그아웃되도록 동작

## 💬 리뷰 포인트
토큰 저장 위치를 localStorage → sessionStorage로 바꿨습니다. 탭 단위로 분리되어 탭을 닫으면 로그아웃되는 방식이 맞는지 확인 부탁드립니다.

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료