### PR TITLE
[feat] 내정보수정 패스워드 인증 (#43)

### DIFF
--- a/app/components/edit-profile/PasswordVerifyStep.tsx
+++ b/app/components/edit-profile/PasswordVerifyStep.tsx
@@ -9,17 +9,31 @@ interface PasswordVerifyStepProps {
   currentPassword: string;
   onChange: (value: string) => void;
   onSubmit: (e: React.FormEvent) => void;
+  error?: string;
+  isLoading?: boolean;
 }
 
-export function PasswordVerifyStep({ currentPassword, onChange, onSubmit }: PasswordVerifyStepProps) {
+export function PasswordVerifyStep({
+  currentPassword,
+  onChange,
+  onSubmit,
+  error,
+  isLoading,
+}: PasswordVerifyStepProps) {
   return (
-    <motion.div className={styles.card} initial={{ opacity: 0, y: 30 }} animate={{ opacity: 1, y: 0 }}>
+    <motion.div
+      className={styles.card}
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
       <div className={styles.head}>
         <Icon3D className={styles.iconWrap}>
           <Shield style={{ width: "4rem", height: "4rem", color: "#E4FF30" }} />
         </Icon3D>
         <h1 className={styles.title}>보안 확인</h1>
-        <p className={styles.subtitle}>내정보를 수정하기 위해 현재 비밀번호를 입력해주세요</p>
+        <p className={styles.subtitle}>
+          내정보를 수정하기 위해 현재 비밀번호를 입력해주세요
+        </p>
       </div>
 
       <form onSubmit={onSubmit}>
@@ -38,9 +52,27 @@ export function PasswordVerifyStep({ currentPassword, onChange, onSubmit }: Pass
           />
         </div>
 
-        <motion.button type="submit" className={styles.submitBtn} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-          확인
+        <motion.button
+          type="submit"
+          className={styles.submitBtn}
+          whileHover={{ scale: isLoading ? 1 : 1.02 }}
+          whileTap={{ scale: isLoading ? 1 : 0.98 }}
+          disabled={isLoading}
+        >
+          {isLoading ? "확인 중..." : "확인"}
         </motion.button>
+        {error && (
+          <p
+            style={{
+              color: "#ff6b6b",
+              marginTop: "0.75rem",
+              fontSize: "0.875rem",
+              textAlign: "center",
+            }}
+          >
+            {error}
+          </p>
+        )}
       </form>
     </motion.div>
   );

--- a/app/edit-profile/page.tsx
+++ b/app/edit-profile/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { motion } from "motion/react";
 import { ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { AxiosError } from "axios";
 import { PasswordVerifyStep } from "@/app/components/edit-profile/PasswordVerifyStep";
 import { EditProfileForm } from "@/app/components/edit-profile/EditProfileForm";
+import { login } from "@/src/api/auth";
+import { fetchUserProfile } from "@/src/api/mypage";
 import { editProfileFormInitial } from "@/src/mocks/data/user";
 import styles from "./page.module.scss";
 
@@ -15,10 +18,33 @@ export default function EditProfilePage() {
   const [step, setStep] = useState<"password" | "edit">("password");
   const [currentPassword, setCurrentPassword] = useState("");
   const [formData, setFormData] = useState(editProfileFormInitial);
+  const [userEmail, setUserEmail] = useState("");
+  const [verifyError, setVerifyError] = useState("");
+  const [isVerifying, setIsVerifying] = useState(false);
 
-  const handlePasswordVerify = (e: React.FormEvent) => {
+  useEffect(() => {
+    fetchUserProfile().then((data) => {
+      if (data) setUserEmail(data.email);
+    });
+  }, []);
+
+  const handlePasswordVerify = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (currentPassword) setStep("edit");
+    setVerifyError("");
+    setIsVerifying(true);
+
+    try {
+      await login(userEmail, currentPassword);
+      setStep("edit");
+    } catch (err) {
+      const axiosError = err as AxiosError<{ message?: string }>;
+      const message =
+        axiosError.response?.data?.message ??
+        "비밀번호가 올바르지 않습니다. 다시 시도해 주세요.";
+      setVerifyError(message);
+    } finally {
+      setIsVerifying(false);
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -60,6 +86,8 @@ export default function EditProfilePage() {
             currentPassword={currentPassword}
             onChange={setCurrentPassword}
             onSubmit={handlePasswordVerify}
+            error={verifyError}
+            isLoading={isVerifying}
           />
         ) : (
           <EditProfileForm

--- a/src/mocks/data/user.ts
+++ b/src/mocks/data/user.ts
@@ -1,7 +1,7 @@
 // 내 프로필 조회 (홈페이지 헤더 Mock)
 export const userProfile = {
   id: 1,
-  email: "user@example.com",
+  email: "user@test.com",
   nickname: "최강001Team",
   birth_date: "1995-06-15",
   profile_img_url: "/images/profile-mock.png",


### PR DESCRIPTION
## 🩵PR 요약
- 내정보수정 패스워드 인증

## 📌 관련 이슈
Closes #43

## 📄 상세 내용
- [ ] 내정보 수정할시 실제 login API 호출 패스워드 인증

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료