### PR TITLE
[feat] 마이페이지 내 게임취향 조회 API 연동 (#51)

### DIFF
--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -9,6 +9,7 @@ import { PreferencesModal } from "@/app/components/mypage/PreferencesModal";
 import {
   putPreferences,
   fetchUserProfile,
+  fetchPreferences,
   UserProfile,
 } from "@/src/api/mypage";
 import {
@@ -73,17 +74,14 @@ export default function MyPage() {
 
   // 게임 취향 fetch
   useEffect(() => {
-    fetch("/api/mypage/preferences")
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: Preferences | null) => {
-        if (data) {
-          setPreferences(data);
-          setSelectedGenres(data.genres.map((g) => g.name));
-          setSelectedPlatforms(data.platforms.map((p) => p.name));
-          setSelectedThemes(data.tags.map((t) => t.name));
-        }
-      })
-      .catch(() => {});
+    fetchPreferences().then((data) => {
+      if (data) {
+        setPreferences(data);
+        setSelectedGenres(data.genres.map((g) => g.name));
+        setSelectedPlatforms(data.platforms.map((p) => p.name));
+        setSelectedThemes(data.tags.map((t) => t.name));
+      }
+    });
   }, []);
 
   // 위시리스트 fetch

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,4 +1,4 @@
-import { apiClient, authApiClient } from "@/src/lib/api";
+import { authApiClient } from "@/src/lib/api";
 
 export interface UserProfile {
   id: number;
@@ -33,16 +33,27 @@ export interface PreferencesResponse {
   tags: { id: number; name: string }[];
 }
 
+export async function fetchPreferences(): Promise<PreferencesResponse | null> {
+  try {
+    const { data } = await authApiClient.get<PreferencesResponse>(
+      "/api/v1/preferences/me/"
+    );
+    return data;
+  } catch {
+    return null;
+  }
+}
+
 export async function putPreferences(
   body: PreferencesBody
 ): Promise<PreferencesResponse> {
-  const { data } = await apiClient.put<PreferencesResponse>(
-    "/api/mypage/preferences",
+  const { data } = await authApiClient.put<PreferencesResponse>(
+    "/api/v1/preferences/me/",
     body
   );
   return data;
 }
 
 export async function deleteWishlistItem(id: number): Promise<void> {
-  await apiClient.delete(`/api/wishlist/${id}`);
+  await authApiClient.delete(`/api/wishlist/${id}`);
 }

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { userPreferences, userWishlist } from "../data/user";
+import { userWishlist } from "../data/user";
 import {
   actionGames,
   rpgGames,
@@ -8,13 +8,6 @@ import {
   recentGames,
   aiPickGames,
 } from "../data/games";
-
-// MSW 메모리 store - 취향 수정 시 여기에 저장됨
-const preferencesStore = {
-  genres: [...userPreferences.genres],
-  platforms: [...userPreferences.platforms],
-  tags: [...userPreferences.tags],
-};
 
 // MSW 메모리 store - 위시리스트 (마이페이지용)
 const wishlistStore = {
@@ -43,35 +36,6 @@ export const handlers = [
     return HttpResponse.json(rpgGames);
   }),
 
-  // 게임 취향 조회
-  http.get("/api/mypage/preferences", () => {
-    return HttpResponse.json({
-      genres: preferencesStore.genres,
-      platforms: preferencesStore.platforms,
-      tags: preferencesStore.tags,
-    });
-  }),
-
-  // 게임 취향 수정
-  http.put("/api/mypage/preferences", async ({ request }) => {
-    const body = (await request.json()) as {
-      genres: { id: number; name: string }[];
-      platforms: { id: number; name: string }[];
-      tags: { id: number; name: string }[];
-    };
-
-    preferencesStore.genres = body.genres;
-    preferencesStore.platforms = body.platforms;
-    preferencesStore.tags = body.tags;
-
-    return HttpResponse.json({
-      genres: preferencesStore.genres,
-      platforms: preferencesStore.platforms,
-      tags: preferencesStore.tags,
-    });
-  }),
-
-  // 위시리스트 조회 (마이페이지용)
   http.get("/api/mypage/wishlist", () => {
     return HttpResponse.json(wishlistStore);
   }),


### PR DESCRIPTION
## 🩵PR 요약
- 마이페이지 내 게임취향 조회 API 연동

## 📌 관련 이슈
Closes #51

## 📄 상세 내용
- [ ] 마이페이지 내 게임취향 조회 API 연동

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항
네트워크 에서 API 통신 확인은 했으나 데이터가 없어서 빈화면 출력되고있음

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료