### PR TITLE
[feat] 마이페이지 검색기록 UI 삭제 내취향 에 맞는 게임추천 UI 추가 (#53)

### DIFF
--- a/app/components/mypage/RecommendedGames.module.scss
+++ b/app/components/mypage/RecommendedGames.module.scss
@@ -1,0 +1,123 @@
+@use "../../styles/variables" as *;
+@use "../../styles/mixins" as *;
+
+.section {
+  margin-bottom: 0;
+}
+
+.heading {
+  margin-bottom: 1.5rem;
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: $white;
+}
+
+.empty {
+  color: $white-50;
+  font-size: 0.95rem;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+// 기본: 순위 + 게임명만 한 줄로 표시
+.item {
+  @include glass-card;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 0.75rem;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: $white-10;
+  }
+}
+
+.rank {
+  font-size: 1rem;
+  font-weight: 700;
+  color: $accent;
+  min-width: 2rem;
+  flex-shrink: 0;
+}
+
+.name {
+  font-size: 1rem;
+  font-weight: 500;
+  color: $white;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// -------- 아래는 적합도·뱃지 활성화 시 사용 --------
+// .info {
+//   flex: 1;
+//   display: flex;
+//   flex-direction: column;
+//   gap: 0.35rem;
+//   min-width: 0;
+// }
+//
+// .scoreBar {
+//   height: 4px;
+//   border-radius: 2px;
+//   background: $white-10;
+//   overflow: hidden;
+// }
+//
+// .scoreFill {
+//   height: 100%;
+//   border-radius: 2px;
+//   background: linear-gradient(90deg, $accent 0%, #a8ff78 100%);
+//   transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+// }
+//
+// .scoreText {
+//   display: flex;
+//   align-items: center;
+//   gap: 0.3rem;
+//   font-size: 0.8rem;
+//   color: $white-50;
+// }
+//
+// .badges {
+//   display: flex;
+//   flex-direction: column;
+//   gap: 0.35rem;
+//   flex-shrink: 0;
+// }
+//
+// %badge-base {
+//   display: flex;
+//   align-items: center;
+//   gap: 0.25rem;
+//   padding: 0.2rem 0.6rem;
+//   border-radius: 999px;
+//   font-size: 0.75rem;
+//   font-weight: 600;
+// }
+//
+// .badgeSaved {
+//   @extend %badge-base;
+//   background: rgba(228, 255, 48, 0.15);
+//   color: $accent;
+// }
+//
+// .badgeLike {
+//   @extend %badge-base;
+//   background: rgba(255, 100, 130, 0.15);
+//   color: #ff6482;
+// }
+//
+// .badgeDislike {
+//   @extend %badge-base;
+//   background: rgba(255, 255, 255, 0.08);
+//   color: $white-50;
+// }
+

--- a/app/components/mypage/RecommendedGames.tsx
+++ b/app/components/mypage/RecommendedGames.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { motion } from "motion/react";
+// import { Heart, Bookmark, Star } from "lucide-react"; // 뱃지 표시 시 활성화
+import styles from "./RecommendedGames.module.scss";
+import { RecommendedGame } from "@/src/api/mypage";
+
+interface RecommendedGamesProps {
+  games: RecommendedGame[];
+}
+
+// 아래 함수들은 뱃지/점수 표시 시 활성화
+// function likeLabel(state: number): string {
+//   if (state === 1) return "좋아요";
+//   if (state === -1) return "싫어요";
+//   return "미평가";
+// }
+// function scorePercent(score: number): string {
+//   return `${Math.round(score * 100)}%`;
+// }
+
+export function RecommendedGames({ games }: RecommendedGamesProps) {
+  if (games.length === 0) {
+    return (
+      <div className={styles.section}>
+        <h2 className={styles.heading}>내 취향에 맞는 게임 추천</h2>
+        <p className={styles.empty}>
+          아직 추천할 게임이 없어요. 취향을 설정해 보세요!
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.section}>
+      <h2 className={styles.heading}>내 취향에 맞는 게임 추천</h2>
+      <div className={styles.list}>
+        {games.map((game, index) => (
+          <motion.div
+            key={game.id}
+            className={styles.item}
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.06 }}
+            whileHover={{ scale: 1.01 }}
+          >
+            {/* 순위 */}
+            <span className={styles.rank}>#{index + 1}</span>
+
+            {/* 게임명 */}
+            <span className={styles.name}>{game.name}</span>
+
+            {/* 아래 블록은 적합도 점수 바 표시 시 활성화
+            <div className={styles.info}>
+              <span className={styles.name}>{game.name}</span>
+              <div className={styles.scoreBar}>
+                <div
+                  className={styles.scoreFill}
+                  style={{ width: scorePercent(game.preference_score) }}
+                />
+              </div>
+              <span className={styles.scoreText}>
+                <Star style={{ width: "0.875rem", height: "0.875rem", color: "#E4FF30" }} />
+                적합도 {scorePercent(game.preference_score)}
+              </span>
+            </div>
+            */}
+
+            {/* 아래 블록은 저장됨/좋아요/싫어요 뱃지 표시 시 활성화
+            <div className={styles.badges}>
+              {game.is_saved && (
+                <span className={styles.badgeSaved}>
+                  <Bookmark style={{ width: "0.875rem", height: "0.875rem" }} />
+                  저장됨
+                </span>
+              )}
+              {game.like_state !== 0 && (
+                <span className={game.like_state === 1 ? styles.badgeLike : styles.badgeDislike}>
+                  <Heart style={{ width: "0.875rem", height: "0.875rem" }} />
+                  {likeLabel(game.like_state)}
+                </span>
+              )}
+            </div>
+            */}
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -4,16 +4,17 @@ import { useState, useEffect } from "react";
 import { ProfileHeader } from "@/app/components/mypage/ProfileHeader";
 import { StatsGrid } from "@/app/components/mypage/StatsGrid";
 import { GamePreferences } from "@/app/components/mypage/GamePreferences";
-import { RecentSearches } from "@/app/components/mypage/RecentSearches";
+import { RecommendedGames } from "@/app/components/mypage/RecommendedGames";
 import { PreferencesModal } from "@/app/components/mypage/PreferencesModal";
 import {
   putPreferences,
   fetchUserProfile,
   fetchPreferences,
+  fetchRecommendedGames,
   UserProfile,
+  RecommendedGame,
 } from "@/src/api/mypage";
 import {
-  recentSearches,
   availableGenres,
   availablePlatforms,
   availableThemes,
@@ -61,6 +62,9 @@ export default function MyPage() {
     previous: null,
     results: [],
   });
+  const [recommendedGames, setRecommendedGames] = useState<RecommendedGame[]>(
+    []
+  );
 
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
@@ -92,6 +96,13 @@ export default function MyPage() {
         if (data) setWishlist(data);
       })
       .catch(() => {});
+  }, []);
+
+  // 취향 맞춤 게임 추천 fetch
+  useEffect(() => {
+    fetchRecommendedGames().then((data) => {
+      if (data) setRecommendedGames(data.results);
+    });
   }, []);
 
   const toggleSelection = (
@@ -143,7 +154,7 @@ export default function MyPage() {
           preferences={preferences}
           onEditClick={() => setIsModalOpen(true)}
         />
-        <RecentSearches searches={recentSearches} />
+        <RecommendedGames games={recommendedGames} />
       </div>
 
       <PreferencesModal

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,4 +1,4 @@
-import { authApiClient } from "@/src/lib/api";
+import { authApiClient, apiClient } from "@/src/lib/api";
 
 export interface UserProfile {
   id: number;
@@ -56,4 +56,31 @@ export async function putPreferences(
 
 export async function deleteWishlistItem(id: number): Promise<void> {
   await authApiClient.delete(`/api/wishlist/${id}`);
+}
+
+export interface RecommendedGame {
+  id: number;
+  name: string;
+  is_saved: boolean;
+  like_state: number;
+  preference_score: number;
+  last_interacted_at: string;
+}
+
+export interface RecommendedGamesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: RecommendedGame[];
+}
+
+export async function fetchRecommendedGames(): Promise<RecommendedGamesResponse | null> {
+  try {
+    const { data } = await apiClient.get<RecommendedGamesResponse>(
+      "/api/v1/preferences/me/recommendations/"
+    );
+    return data;
+  } catch {
+    return null;
+  }
 }

--- a/src/mocks/data/preferences.ts
+++ b/src/mocks/data/preferences.ts
@@ -25,7 +25,13 @@ export const availableGenres = [
   "MMORPG",
 ];
 
-export const availablePlatforms = ["PC", "PlayStation", "Xbox", "Nintendo Switch", "Mobile"];
+export const availablePlatforms = [
+  "PC",
+  "PlayStation",
+  "Xbox",
+  "Nintendo Switch",
+  "Mobile",
+];
 
 export const availableThemes = [
   "오픈월드",
@@ -39,3 +45,67 @@ export const availableThemes = [
   "판타지",
   "SF",
 ];
+
+export const recommendedGames = {
+  count: 20,
+  next: null,
+  previous: null,
+  results: [
+    {
+      id: 1,
+      name: "The Witcher 3: Wild Hunt",
+      is_saved: true,
+      like_state: 1,
+      preference_score: 0.9523,
+      last_interacted_at: "2025-05-30T08:00:00Z",
+    },
+    {
+      id: 2,
+      name: "Elden Ring",
+      is_saved: false,
+      like_state: 1,
+      preference_score: 0.9102,
+      last_interacted_at: "2025-05-28T12:00:00Z",
+    },
+    {
+      id: 3,
+      name: "Cyberpunk 2077",
+      is_saved: true,
+      like_state: 0,
+      preference_score: 0.8721,
+      last_interacted_at: "2025-05-25T09:30:00Z",
+    },
+    {
+      id: 4,
+      name: "Red Dead Redemption 2",
+      is_saved: false,
+      like_state: 1,
+      preference_score: 0.8431,
+      last_interacted_at: "2025-05-20T15:00:00Z",
+    },
+    {
+      id: 5,
+      name: "Dark Souls III",
+      is_saved: false,
+      like_state: -1,
+      preference_score: 0.8012,
+      last_interacted_at: "2025-05-18T10:00:00Z",
+    },
+    {
+      id: 6,
+      name: "Baldur's Gate 3",
+      is_saved: true,
+      like_state: 1,
+      preference_score: 0.7856,
+      last_interacted_at: "2025-05-15T14:00:00Z",
+    },
+    {
+      id: 7,
+      name: "God of War: Ragnarök",
+      is_saved: false,
+      like_state: 0,
+      preference_score: 0.7634,
+      last_interacted_at: "2025-05-10T11:00:00Z",
+    },
+  ],
+};

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -8,6 +8,7 @@ import {
   recentGames,
   aiPickGames,
 } from "../data/games";
+import { recommendedGames } from "../data/preferences";
 
 // MSW 메모리 store - 위시리스트 (마이페이지용)
 const wishlistStore = {
@@ -72,5 +73,10 @@ export const handlers = [
   // 추천 - AI 추천
   http.get("/api/recommend/ai-pick-games", () => {
     return HttpResponse.json(aiPickGames);
+  }),
+
+  // 마이페이지 - 취향 맞춤 게임 추천
+  http.get("/api/v1/preferences/me/recommendations/", () => {
+    return HttpResponse.json(recommendedGames);
   }),
 ];


### PR DESCRIPTION
## 🩵PR 요약
- 마이페이지 검색기록 UI 삭제 내취향 에 맞는 게임추천 UI 추가

## 📌 관련 이슈
Closes #53

## 📄 상세 내용
- [ ] 마이페이지 검색기록 UI 삭제 내취향 에 맞는 게임추천 UI 추가
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
<img width="945" height="768" alt="내취향에맞는게임추천" src="https://github.com/user-attachments/assets/83bfdb8f-fa6e-4841-9a6b-dc98d084c330" />

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료