### PR TITLE
[fix] 내정보 수정 비밀번호 확인 삭제, 위시리스트 UI 수정 (#55)

### DIFF
--- a/app/components/edit-profile/EditProfileForm.module.scss
+++ b/app/components/edit-profile/EditProfileForm.module.scss
@@ -90,8 +90,8 @@
 
 .cancelBtn {
   flex: 1;
+  width: 100%;
   @include btn-ghost;
   padding: 0.75rem;
   text-align: center;
 }
-

--- a/app/components/edit-profile/EditProfileForm.tsx
+++ b/app/components/edit-profile/EditProfileForm.tsx
@@ -19,17 +19,34 @@ interface EditProfileFormProps {
 }
 
 const passwordFields = [
-  { label: "현재 비밀번호", name: "currentPasswordEdit" as const, placeholder: "현재 비밀번호" },
-  { label: "새 비밀번호", name: "newPassword" as const, placeholder: "새 비밀번호 (8자 이상)" },
-  { label: "새 비밀번호 확인", name: "confirmPassword" as const, placeholder: "새 비밀번호 확인" },
+  {
+    label: "새 비밀번호",
+    name: "newPassword" as const,
+    placeholder: "새 비밀번호 (8자 이상)",
+  },
+  {
+    label: "새 비밀번호 확인",
+    name: "confirmPassword" as const,
+    placeholder: "새 비밀번호 확인",
+  },
 ];
 
-export function EditProfileForm({ formData, onChange, onSubmit }: EditProfileFormProps) {
+export function EditProfileForm({
+  formData,
+  onChange,
+  onSubmit,
+}: EditProfileFormProps) {
   return (
-    <motion.div className={styles.form} initial={{ opacity: 0, y: 30 }} animate={{ opacity: 1, y: 0 }}>
+    <motion.div
+      className={styles.form}
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
       <div className={styles.header}>
         <h1 className={styles.title}>내정보 수정</h1>
-        <p className={styles.subtitle}>회원정보를 안전하게 변경할 수 있습니다</p>
+        <p className={styles.subtitle}>
+          회원정보를 안전하게 변경할 수 있습니다
+        </p>
       </div>
 
       <form onSubmit={onSubmit} className={styles.fields}>
@@ -55,7 +72,9 @@ export function EditProfileForm({ formData, onChange, onSubmit }: EditProfileFor
 
         <div className={styles.pwSection}>
           <h2 className={styles.sectionTitle}>비밀번호 변경</h2>
-          <p className={styles.hint}>비밀번호를 변경하지 않으려면 아래 필드를 비워두세요</p>
+          <p className={styles.hint}>
+            비밀번호를 변경하지 않으려면 아래 필드를 비워두세요
+          </p>
 
           {passwordFields.map(({ label, name, placeholder }) => (
             <div key={name}>
@@ -78,11 +97,21 @@ export function EditProfileForm({ formData, onChange, onSubmit }: EditProfileFor
         </div>
 
         <div className={styles.actions}>
-          <motion.button type="submit" className={styles.saveBtn} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+          <motion.button
+            type="submit"
+            className={styles.saveBtn}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+          >
             저장하기
           </motion.button>
           <Link href="/mypage" style={{ flex: 1 }}>
-            <motion.button type="button" className={styles.cancelBtn} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <motion.button
+              type="button"
+              className={styles.cancelBtn}
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
               취소
             </motion.button>
           </Link>

--- a/app/components/mypage/GamePreferences.module.scss
+++ b/app/components/mypage/GamePreferences.module.scss
@@ -22,11 +22,17 @@
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
   font-size: 0.875rem;
+  font-weight: 500;
   color: $white;
-  transition: background 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
 
   &:hover {
-    background: $white-10;
+    background: rgba(228, 255, 48, 0.1);
+    color: $accent;
+    border-color: rgba(228, 255, 48, 0.3);
   }
 }
 
@@ -65,4 +71,3 @@
   font-size: 0.875rem;
   color: $accent;
 }
-

--- a/app/components/mypage/ProfileHeader.module.scss
+++ b/app/components/mypage/ProfileHeader.module.scss
@@ -1,15 +1,29 @@
 @use "../../styles/variables" as *;
 @use "../../styles/mixins" as *;
+
 .header {
   @include glass-card;
   margin-bottom: 2rem;
-  padding: 2rem;
+  padding: 1.5rem;
   border-radius: 0.5rem;
+
+  @include respond-md {
+    padding: 2rem;
+  }
 }
 
+/* 모바일: 세로 중앙 / 데스크탑: 가로 */
 .inner {
-  @include flex-center(2rem);
-  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+
+  @include respond-md {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 2rem;
+  }
 }
 
 .avatar {
@@ -17,40 +31,68 @@
 }
 
 .avatarCircle {
-  width: 8rem;
-  height: 8rem;
+  width: 6rem;
+  height: 6rem;
   border-radius: 9999px;
   background: linear-gradient(135deg, #e4ff30, #b8cc26);
   display: flex;
   align-items: center;
   justify-content: center;
+
+  @include respond-md {
+    width: 8rem;
+    height: 8rem;
+  }
 }
 
+/* 모바일: 텍스트 중앙 / 데스크탑: 좌측 */
 .userInfo {
   flex: 1;
+  width: 100%;
+  text-align: center;
+
+  @include respond-md {
+    text-align: left;
+  }
 }
 
 .nickname {
   margin-bottom: 0.5rem;
-  font-size: 2.25rem;
+  font-size: 1.75rem;
   font-weight: 700;
   color: $white;
+
+  @include respond-md {
+    font-size: 2.25rem;
+  }
 }
 
 .email {
+  justify-content: center;
   @include flex-center(0.5rem);
   margin-bottom: 1rem;
   color: $white-50;
+  font-size: 0.9rem;
+
+  @include respond-md {
+    justify-content: flex-start;
+  }
 }
 
 .bio {
   margin-bottom: 1.5rem;
   color: $white-70;
+  font-size: 0.9rem;
 }
 
 .actions {
   display: flex;
+  justify-content: center;
   gap: 0.75rem;
+
+  @include respond-md {
+    justify-content: flex-start;
+  }
 }
 
 .editBtn {
@@ -58,9 +100,10 @@
   background: $accent;
   color: $black;
   font-weight: 700;
-  padding: 0.5rem 1.5rem;
+  padding: 0.5rem 1.25rem;
   border-radius: 0.5rem;
   cursor: pointer;
+  font-size: 0.875rem;
   transition: background 0.2s ease;
 
   &:hover {
@@ -72,13 +115,13 @@
   @include flex-center(0.5rem);
   @include glass-card;
   color: $white;
-  padding: 0.5rem 1.5rem;
+  padding: 0.5rem 1.25rem;
   border-radius: 0.5rem;
   cursor: pointer;
+  font-size: 0.875rem;
   transition: background 0.2s ease;
 
   &:hover {
     background: $white-10;
   }
 }
-

--- a/app/components/mypage/StatsGrid.module.scss
+++ b/app/components/mypage/StatsGrid.module.scss
@@ -5,35 +5,70 @@
   margin-bottom: 2rem;
 }
 
-.card {
-  @include glass-card;
-  display: inline-block;
-  padding: 1.5rem;
-  border-radius: 0.5rem;
-  margin-bottom: 1.5rem;
+/* 섹션 헤더 */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
 }
 
-.iconWrap {
-  margin-bottom: 0.75rem;
+.titleRow {
+  @include flex-center(0.5rem);
 }
 
-.count {
-  margin-bottom: 0.25rem;
+.heading {
   font-size: 1.875rem;
   font-weight: 700;
   color: $white;
 }
 
-.label {
+.count {
+  font-size: 1rem;
+  font-weight: 700;
+  color: $accent;
+  background: rgba(228, 255, 48, 0.12);
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+}
+
+.moreBtn {
+  @include glass-card;
+  @include flex-center(0.25rem);
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
   font-size: 0.875rem;
-  color: $white-50;
+  font-weight: 500;
+  color: $white;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+
+  &:hover {
+    background: rgba(228, 255, 48, 0.1);
+    color: $accent;
+    border-color: rgba(228, 255, 48, 0.3);
+  }
 }
 
 /* 위시리스트 아이템 목록 */
 .wishlistGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
+  // 기본값 (Mobile): 1열
+  grid-template-columns: repeat(1, 1fr);
+
+  // Tablet (768px 이상): 2열
+  @include respond-md {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  // PC (1024px 이상): 4열
+  @include respond-lg {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .wishlistCard {
@@ -43,6 +78,7 @@
   gap: 0.75rem;
   padding: 0.875rem 1rem;
   border-radius: 0.5rem;
+  min-width: 0; // 그리드 컬럼 초과 방지
   transition:
     transform 0.2s ease,
     background 0.2s ease;
@@ -81,10 +117,11 @@
 }
 
 .wishlistInfo {
+  flex: 1; // 남은 공간 모두 차지
+  min-width: 0; // 텍스트 말줄임 동작 보장
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  min-width: 0;
 }
 
 .wishlistName {

--- a/app/components/mypage/StatsGrid.tsx
+++ b/app/components/mypage/StatsGrid.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { motion } from "motion/react";
+import Link from "next/link";
 import Image from "next/image";
-import { Heart, Star } from "lucide-react";
-import { Icon3D } from "@/app/components/common/Icon3D";
+import { Heart, Star, ChevronRight } from "lucide-react";
 import styles from "./StatsGrid.module.scss";
 
 interface WishlistItem {
@@ -23,31 +23,35 @@ interface StatsGridProps {
 export function StatsGrid({ wishlistCount, wishlistItems }: StatsGridProps) {
   return (
     <div className={styles.section}>
-      {/* 위시리스트 카운트 카드 */}
-      <motion.div
-        className={styles.card}
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.1 }}
-      >
-        <Icon3D className={styles.iconWrap}>
+      {/* 섹션 헤더: 타이틀 + 카운트 + 더보기 버튼 */}
+      <div className={styles.header}>
+        <div className={styles.titleRow}>
           <Heart
-            style={{ width: "1.5rem", height: "1.5rem", color: "#E4FF30" }}
+            style={{ width: "1.25rem", height: "1.25rem", color: "#E4FF30" }}
           />
-        </Icon3D>
-        <p className={styles.count}>{wishlistCount}</p>
-        <p className={styles.label}>위시리스트</p>
-      </motion.div>
+          <h2 className={styles.heading}>위시리스트</h2>
+          <span className={styles.count}>{wishlistCount}</span>
+        </div>
+        <Link href="/wishlist">
+          <motion.button
+            className={styles.moreBtn}
+            whileHover={{ scale: 1.03 }}
+            whileTap={{ scale: 0.97 }}
+          >
+            더보기
+            <ChevronRight style={{ width: "1rem", height: "1rem" }} />
+          </motion.button>
+        </Link>
+      </div>
 
       {/* 위시리스트 아이템 목록 */}
       <div className={styles.wishlistGrid}>
-        {wishlistItems.map((item) => (
+        {wishlistItems.slice(0, 8).map((item) => (
           <motion.div
             key={item.id}
             className={styles.wishlistCard}
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            // transition={{ delay: 0.1 + index * 0.05 }}
             whileHover={{ y: -2 }}
           >
             <div className={styles.wishlistThumb}>

--- a/app/edit-profile/page.module.scss
+++ b/app/edit-profile/page.module.scss
@@ -8,7 +8,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-top: 5rem;
+  padding-top: 10rem;
   padding-bottom: 5rem;
 }
 
@@ -20,4 +20,3 @@
   padding-left: 1.5rem;
   padding-right: 1.5rem;
 }
-

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -88,6 +88,12 @@
     @content;
   }
 }
+// ─── sm 브레이크포인트 (480px) ─────────────────────────────────
+@mixin respond-xs {
+  @media (min-width: 480px) {
+    @content;
+  }
+}
 
 // ─── accent 배지 ──────────────────────────────────────────────
 @mixin accent-badge {

--- a/src/mocks/data/user.ts
+++ b/src/mocks/data/user.ts
@@ -20,7 +20,7 @@ export const userPreferences = {
 
 // 위시리스트
 export const userWishlist = {
-  count: 5,
+  count: 11,
   next: null,
   previous: null,
   results: [
@@ -63,6 +63,54 @@ export const userWishlist = {
       thumbnail_img_url: "https://cdn.example.com/hk.jpg",
       rawg_rating: 4.42,
       saved_at: "2025-05-05T20:00:00Z",
+    },
+    {
+      id: 6,
+      name: "Baldur's Gate 3",
+      slug: "baldurs-gate-3",
+      thumbnail_img_url: "https://cdn.example.com/bg3.jpg",
+      rawg_rating: 4.91,
+      saved_at: "2025-05-01T11:00:00Z",
+    },
+    {
+      id: 7,
+      name: "Dark Souls III",
+      slug: "dark-souls-3",
+      thumbnail_img_url: "https://cdn.example.com/ds3.jpg",
+      rawg_rating: 4.53,
+      saved_at: "2025-04-28T16:00:00Z",
+    },
+    {
+      id: 8,
+      name: "Sekiro: Shadows Die Twice",
+      slug: "sekiro-shadows-die-twice",
+      thumbnail_img_url: "https://cdn.example.com/sekiro.jpg",
+      rawg_rating: 4.61,
+      saved_at: "2025-04-25T09:30:00Z",
+    },
+    {
+      id: 9,
+      name: "God of War",
+      slug: "god-of-war",
+      thumbnail_img_url: "https://cdn.example.com/gow.jpg",
+      rawg_rating: 4.77,
+      saved_at: "2025-04-20T14:00:00Z",
+    },
+    {
+      id: 10,
+      name: "Hades",
+      slug: "hades",
+      thumbnail_img_url: "https://cdn.example.com/hades.jpg",
+      rawg_rating: 4.69,
+      saved_at: "2025-04-15T18:00:00Z",
+    },
+    {
+      id: 11,
+      name: "Stardew Valley",
+      slug: "stardew-valley",
+      thumbnail_img_url: "https://cdn.example.com/stardew.jpg",
+      rawg_rating: 4.55,
+      saved_at: "2025-04-10T10:00:00Z",
     },
   ],
 };


### PR DESCRIPTION
## 🩵PR 요약
- 내정보 수정 비밀번호 확인 삭제, 위시리스트 UI 수정

## 📌 관련 이슈
Closes #55

## 📄 상세 내용
- [ ] 내정보 수정 비밀번호 확인 삭제
- [ ] 위시리스트 UI 수정
- [ ] 위시리스트 UI , 프로필헤더 반응형

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

<img width="1373" height="495" alt="위시리스트" src="https://github.com/user-attachments/assets/34b9e400-0911-4e79-8cfc-1cfd5d986e9c" />

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료