### PR TITLE
[feat] 비밀번호 확인 API 연동 (#63)

### DIFF
--- a/app/edit-profile/page.tsx
+++ b/app/edit-profile/page.tsx
@@ -8,8 +8,7 @@ import { useRouter } from "next/navigation";
 import { AxiosError } from "axios";
 import { PasswordVerifyStep } from "@/app/components/edit-profile/PasswordVerifyStep";
 import { EditProfileForm } from "@/app/components/edit-profile/EditProfileForm";
-import { login } from "@/src/api/auth";
-import { fetchUserProfile } from "@/src/api/mypage";
+import { fetchUserProfile, verifyPassword } from "@/src/api/mypage";
 import { authApiClient } from "@/src/lib/api";
 import { editProfileFormInitial } from "@/src/mocks/data/user";
 import styles from "./page.module.scss";
@@ -35,14 +34,14 @@ export default function EditProfilePage() {
     setIsVerifying(true);
 
     try {
-      await login(userEmail, currentPassword);
-      setStep("edit");
+      const isValid = await verifyPassword(currentPassword);
+      if (isValid) {
+        setStep("edit");
+      } else {
+        setVerifyError("비밀번호가 올바르지 않습니다. 다시 시도해 주세요.");
+      }
     } catch (err) {
-      const axiosError = err as AxiosError<{ message?: string }>;
-      const message =
-        axiosError.response?.data?.message ??
-        "비밀번호가 올바르지 않습니다. 다시 시도해 주세요.";
-      setVerifyError(message);
+      setVerifyError("인증 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     } finally {
       setIsVerifying(false);
     }

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -21,6 +21,18 @@ export async function fetchUserProfile(): Promise<UserProfile | null> {
   }
 }
 
+export async function verifyPassword(password: string): Promise<boolean> {
+  try {
+    const { status } = await authApiClient.post(
+      "/api/v1/users/me/verify-password/",
+      { password }
+    );
+    return status === 200;
+  } catch {
+    return false;
+  }
+}
+
 export interface PreferencesBody {
   genre_ids: number[];
   platform_ids: number[];


### PR DESCRIPTION
## 🩵PR 요약
- 비밀번호 확인 API 연동

## 📌 관련 이슈
Closes #63

## 📄 상세 내용
- [ ] 내정보 수정하기 진입 전 비밀번호 확인 API 연동

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료