### PR TITLE
[feat] 마이페이지 위시리스트 API 연동 (#83)

### DIFF
--- a/app/components/mypage/StatsGrid.tsx
+++ b/app/components/mypage/StatsGrid.tsx
@@ -4,20 +4,12 @@ import { motion } from "motion/react";
 import Link from "next/link";
 import Image from "next/image";
 import { Heart, Star, ChevronRight } from "lucide-react";
+import { SavedGame } from "@/src/api/mypage";
 import styles from "./StatsGrid.module.scss";
-
-interface WishlistItem {
-  id: number;
-  name: string;
-  slug: string;
-  thumbnail_img_url: string;
-  rawg_rating: number;
-  saved_at: string;
-}
 
 interface StatsGridProps {
   wishlistCount: number;
-  wishlistItems: WishlistItem[];
+  wishlistItems: SavedGame[];
 }
 
 export function StatsGrid({ wishlistCount, wishlistItems }: StatsGridProps) {

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -13,8 +13,10 @@ import {
   fetchUserProfile,
   fetchPreferences,
   fetchRecommendedGames,
+  fetchSavedGames,
   UserProfile,
   RecommendedGame,
+  SavedGamesResponse,
 } from "@/src/api/mypage";
 import {
   availableGenres,
@@ -34,22 +36,6 @@ interface Preferences {
   tags: PreferenceItem[];
 }
 
-interface WishlistItem {
-  id: number;
-  name: string;
-  slug: string;
-  thumbnail_img_url: string;
-  rawg_rating: number;
-  saved_at: string;
-}
-
-interface Wishlist {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: WishlistItem[];
-}
-
 export default function MyPage() {
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -59,7 +45,7 @@ export default function MyPage() {
     tags: [],
   });
   const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [wishlist, setWishlist] = useState<Wishlist>({
+  const [wishlist, setWishlist] = useState<SavedGamesResponse>({
     count: 0,
     next: null,
     previous: null,
@@ -96,12 +82,9 @@ export default function MyPage() {
           setSelectedThemes(data.tags.map((t) => t.name));
         }
       }),
-      fetch("/api/mypage/wishlist")
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data: Wishlist | null) => {
-          if (data) setWishlist(data);
-        })
-        .catch(() => {}),
+      fetchSavedGames().then((data) => {
+        if (data) setWishlist(data);
+      }),
       fetchRecommendedGames().then((data) => {
         if (data) setRecommendedGames(data.results);
       }),

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -85,3 +85,31 @@ export async function fetchRecommendedGames(): Promise<RecommendedGamesResponse 
     return null;
   }
 }
+
+/** GET /api/v1/preferences/me/saved-games/ - 위시리스트(찜한 게임) 목록 */
+export interface SavedGame {
+  id: number;
+  name: string;
+  slug: string;
+  thumbnail_img_url: string;
+  rawg_rating: number;
+  saved_at: string;
+}
+
+export interface SavedGamesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: SavedGame[];
+}
+
+export async function fetchSavedGames(): Promise<SavedGamesResponse | null> {
+  try {
+    const { data } = await authApiClient.get<SavedGamesResponse>(
+      "/api/v1/preferences/me/saved-games/"
+    );
+    return data;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 🩵PR 요약
- 마이페이지 위시리스트 API 연동

## 📌 관련 이슈
Closes #83

## 📄 상세 내용
- [ ] 마이페이지 위시리스트 API 연동

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<img width="1010" height="357" alt="마이페이지위시리스트" src="https://github.com/user-attachments/assets/8e32a590-1983-41d8-9cdb-87e36adc4a1b" />

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료