### PR TITLE
[feat] 위시리스트 페이지 API 연동 (#85)

### DIFF
--- a/app/components/wishlist/WishlistItem.tsx
+++ b/app/components/wishlist/WishlistItem.tsx
@@ -4,19 +4,11 @@ import { motion } from "motion/react";
 import Image from "next/image";
 import { Star, X } from "lucide-react";
 import Link from "next/link";
+import { SavedGame } from "@/src/api/mypage";
 import styles from "./WishlistItem.module.scss";
 
-interface WishlistGame {
-  id: number;
-  name: string;
-  slug: string;
-  thumbnail_img_url: string;
-  rawg_rating: number;
-  saved_at: string;
-}
-
 interface WishlistItemProps {
-  game: WishlistGame;
+  game: SavedGame;
   index: number;
   onRemove: (id: number) => void;
 }

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -1,23 +1,35 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { WishlistHeader } from "@/app/components/wishlist/WishlistHeader";
 import { WishlistItem } from "@/app/components/wishlist/WishlistItem";
 import { WishlistEmpty } from "@/app/components/wishlist/WishlistEmpty";
 import { WishlistSummary } from "@/app/components/wishlist/WishlistSummary";
-import { deleteWishlistItem } from "@/src/api/mypage";
-import { userWishlist } from "@/src/mocks/data/user";
+import { fetchSavedGames, SavedGame } from "@/src/api/mypage";
+import { authApiClient } from "@/src/lib/api";
 import styles from "./page.module.scss";
 
 type SortType = "all" | "rating_high" | "rating_low";
 
 export default function WishlistPage() {
-  const [games, setGames] = useState(userWishlist.results);
+  const [games, setGames] = useState<SavedGame[]>([]);
   const [sort, setSort] = useState<SortType>("all");
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    fetchSavedGames()
+      .then((data) => {
+        if (data) setGames(data.results);
+      })
+      .finally(() => setIsLoaded(true));
+  }, []);
 
   const removeFromWishlist = async (id: number) => {
     try {
-      await deleteWishlistItem(id);
+      await authApiClient.patch(`/api/v1/preferences/games/${id}/`, {
+        is_saved: false,
+        reaction: "neutral",
+      });
       setGames((prev) => prev.filter((game) => game.id !== id));
     } catch (err) {
       console.error("위시리스트 삭제 오류:", err);
@@ -29,6 +41,8 @@ export default function WishlistPage() {
     if (sort === "rating_low") return a.rawg_rating - b.rawg_rating;
     return 0;
   });
+
+  if (!isLoaded) return null;
 
   return (
     <div className={styles.page}>


### PR DESCRIPTION
## 🩵PR 요약
- 위시리스트 페이지 API 연동

## 📌 관련 이슈
Closes #85

## 📄 상세 내용
- [x] 위시리스트 페이지 API 연동
- [x] X 클릭시 삭제 구현

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<img width="1028" height="672" alt="위시리스트api" src="https://github.com/user-attachments/assets/8d5a734f-3caa-4819-8034-9833d55bde60" />

## 🧠 기타 참고사항
위시리스트 아이템 클릭시 상세페이지는 아직 미구현

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료