### PR TITLE
[feat] Discord 로그인 API 연결 (#87)

### DIFF
--- a/app/components/login/LoginForm.tsx
+++ b/app/components/login/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { motion } from "motion/react";
 import { Lock, User } from "lucide-react";
 import Link from "next/link";
+import { getOAuthLoginUrl } from "@/src/api/auth";
 import { KakaoIcon, DiscordIcon } from "@/app/components/common/SocialIcons";
 import styles from "./LoginForm.module.scss";
 
@@ -113,13 +114,7 @@ export function LoginForm({
             type="button"
             className={`${styles.socialBtn} ${styles.socialKakao}`}
             onClick={() => {
-              const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-              const redirectUri = encodeURIComponent(
-                typeof window !== "undefined"
-                  ? `${window.location.origin}/auth/callback`
-                  : "/auth/callback"
-              );
-              window.location.href = `${base}/api/v1/auth/kakao/login/?redirect_uri=${redirectUri}`;
+              window.location.href = getOAuthLoginUrl("kakao");
             }}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
@@ -130,10 +125,11 @@ export function LoginForm({
           <motion.button
             type="button"
             className={`${styles.socialBtn} ${styles.socialDiscord}`}
-            disabled
-            title="준비 중"
-            whileHover={undefined}
-            whileTap={undefined}
+            onClick={() => {
+              window.location.href = getOAuthLoginUrl("discord");
+            }}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
           >
             <DiscordIcon />
             Discord로 계속하기

--- a/app/components/signup/SignupForm.tsx
+++ b/app/components/signup/SignupForm.tsx
@@ -34,7 +34,7 @@ interface SignupFormProps {
   isSubmitting: boolean;
 }
 
-const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+import { getOAuthLoginUrl } from "@/src/api/auth";
 
 export function SignupForm({
   step,
@@ -62,12 +62,11 @@ export function SignupForm({
   isSubmitting,
 }: SignupFormProps) {
   const handleSocialKakao = () => {
-    const redirectUri = encodeURIComponent(
-      typeof window !== "undefined"
-        ? `${window.location.origin}/auth/callback`
-        : "/auth/callback"
-    );
-    window.location.href = `${apiBase}/api/v1/auth/kakao/login/?redirect_uri=${redirectUri}`;
+    window.location.href = getOAuthLoginUrl("kakao");
+  };
+
+  const handleSocialDiscord = () => {
+    window.location.href = getOAuthLoginUrl("discord");
   };
 
   return (
@@ -296,10 +295,9 @@ export function SignupForm({
         <motion.button
           type="button"
           className={`${styles.socialBtn} ${styles.socialDiscord}`}
-          disabled
-          title="준비 중"
-          whileHover={undefined}
-          whileTap={undefined}
+          onClick={handleSocialDiscord}
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
         >
           <DiscordIcon />
           Discord로 가입하기

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -128,3 +128,13 @@ export async function requestPasswordReset(
   );
   return data;
 }
+
+/** 소셜 로그인(카카오/디스코드) 리다이렉트 URL */
+export function getOAuthLoginUrl(provider: "kakao" | "discord"): string {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+  const redirectUri =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/auth/callback`
+      : "/auth/callback";
+  return `${base}/api/v1/auth/${provider}/login/?redirect_uri=${encodeURIComponent(redirectUri)}`;
+}


### PR DESCRIPTION
## 🩵PR 요약
로그인/회원가입 페이지의 Discord 소셜 로그인 버튼을 활성화하고 백엔드 API와 연결

## 📌 관련 이슈
Closes #87 

## 📄 상세 내용
- [x] `getOAuthLoginUrl(provider)` 유틸 함수 추가 (카카오/Discord 공통)
- [x] 로그인 페이지 "Discord로 계속하기" 버튼 활성화
- [x] 회원가입 페이지 "Discord로 가입하기" 버튼 활성화
- [x] 카카오 로그인도 `getOAuthLoginUrl`로 통일

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항
백엔드에서 Discord OAuth 후 redirect_uri로 리다이렉트 예상

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료