### PR TITLE
[feat] 나의 선호 장르,플랫폼,태그 리스트 api 연동 (#93)

### DIFF
--- a/app/components/mypage/PreferencesModal.tsx
+++ b/app/components/mypage/PreferencesModal.tsx
@@ -1,12 +1,9 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { X, Check, Gamepad2, Settings, Tag } from "lucide-react";
-import {
-  availableGenres,
-  availablePlatforms,
-  availableThemes,
-} from "@/src/mocks/data/preferences";
+import { X, Check, Gamepad2, Settings, Tag, Loader2 } from "lucide-react";
+import { fetchGenres, fetchPlatforms, fetchTags } from "@/src/api/game";
 import styles from "./PreferencesModal.module.scss";
 
 interface PreferencesModalProps {
@@ -38,6 +35,37 @@ export function PreferencesModal({
   setSelectedPlatforms,
   setSelectedThemes,
 }: PreferencesModalProps) {
+  const [availableGenres, setAvailableGenres] = useState<string[]>([]);
+  const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([]);
+  const [availableThemes, setAvailableThemes] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasFetched, setHasFetched] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || hasFetched) return;
+
+    let cancelled = false;
+
+    Promise.all([fetchGenres(), fetchPlatforms(), fetchTags()])
+      .then(([genres, platforms, tags]) => {
+        if (cancelled) return;
+        setAvailableGenres(genres.map((g) => g.name));
+        setAvailablePlatforms(platforms.map((p) => p.name));
+        setAvailableThemes(tags.map((t) => t.name));
+        setHasFetched(true);
+      })
+      .catch((err) => {
+        console.error("취향 목록 불러오기 실패:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, hasFetched]);
+
   const sections = [
     {
       title: "선호 장르",
@@ -97,52 +125,72 @@ export function PreferencesModal({
               </div>
 
               <div className={styles.body}>
-                {sections.map(
-                  ({ title, icon: Icon, items, selected, setSelected }) => (
-                    <div key={title}>
-                      <h3 className={styles.sectionTitle}>
-                        <Icon
-                          style={{
-                            width: "1.25rem",
-                            height: "1.25rem",
-                            color: "#E4FF30",
-                          }}
-                        />
-                        {title}
-                      </h3>
-                      <div className={styles.tagWrap}>
-                        {items.map((item) => {
-                          const isSelected = selected.includes(item);
-                          return (
-                            <motion.button
-                              key={item}
-                              onClick={() =>
-                                onToggle(item, selected, setSelected)
-                              }
-                              className={
-                                isSelected
-                                  ? styles.tagBtnSelected
-                                  : styles.tagBtnDefault
-                              }
-                              whileHover={{ scale: 1.05 }}
-                              whileTap={{ scale: 0.95 }}
-                            >
-                              {isSelected && (
-                                <Check
-                                  style={{
-                                    display: "inline",
-                                    width: "1rem",
-                                    height: "1rem",
-                                    marginRight: "0.25rem",
-                                  }}
-                                />
-                              )}
-                              {item}
-                            </motion.button>
-                          );
-                        })}
+                {isLoading ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      alignItems: "center",
+                      padding: "3rem 0",
+                    }}
+                  >
+                    <Loader2
+                      style={{
+                        width: "2rem",
+                        height: "2rem",
+                        color: "#E4FF30",
+                        animation: "spin 1s linear infinite",
+                      }}
+                    />
+                  </div>
+                ) : (
+                  sections.map(
+                    ({ title, icon: Icon, items, selected, setSelected }) => (
+                      <div key={title}>
+                        <h3 className={styles.sectionTitle}>
+                          <Icon
+                            style={{
+                              width: "1.25rem",
+                              height: "1.25rem",
+                              color: "#E4FF30",
+                            }}
+                          />
+                          {title}
+                        </h3>
+                        <div className={styles.tagWrap}>
+                          {items.map((item) => {
+                            const isSelected = selected.includes(item);
+                            return (
+                              <motion.button
+                                key={item}
+                                onClick={() =>
+                                  onToggle(item, selected, setSelected)
+                                }
+                                className={
+                                  isSelected
+                                    ? styles.tagBtnSelected
+                                    : styles.tagBtnDefault
+                                }
+                                whileHover={{ scale: 1.05 }}
+                                whileTap={{ scale: 0.95 }}
+                              >
+                                {isSelected && (
+                                  <Check
+                                    style={{
+                                      display: "inline",
+                                      width: "1rem",
+                                      height: "1rem",
+                                      marginRight: "0.25rem",
+                                    }}
+                                  />
+                                )}
+                                {item}
+                              </motion.button>
+                            );
+                          })}
+                        </div>
                       </div>
-                    </div>
+                    )
                   )
                 )}
               </div>

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -18,11 +18,9 @@ import {
   RecommendedGame,
   SavedGamesResponse,
 } from "@/src/api/mypage";
-import {
-  availableGenres,
-  availablePlatforms,
-  availableThemes,
-} from "@/src/mocks/data/preferences";
+import { fetchGenres, fetchPlatforms, fetchTags } from "@/src/api/game";
+import type { GenreItem, PlatformItem, TagItem } from "@/src/api/game";
+import { preferenceNamesToIds } from "@/src/lib/preferences";
 import styles from "./page.module.scss";
 
 interface PreferenceItem {
@@ -60,9 +58,13 @@ export default function MyPage() {
   const [selectedThemes, setSelectedThemes] = useState<string[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
 
+  // API에서 가져온 전체 목록 (id 포함, 저장 시 id 변환에 사용)
+  const [genreList, setGenreList] = useState<GenreItem[]>([]);
+  const [platformList, setPlatformList] = useState<PlatformItem[]>([]);
+  const [tagList, setTagList] = useState<TagItem[]>([]);
+
   // 초기 상태 설정
   useEffect(() => {
-    // getAccessToken()은 클라이언트 사이드에서만 안전하게 실행되도록 구성되어 있다고 가정
     const token = getAccessToken();
     if (!token) {
       router.replace("/login");
@@ -88,15 +90,13 @@ export default function MyPage() {
       fetchRecommendedGames().then((data) => {
         if (data) setRecommendedGames(data.results);
       }),
+      fetchGenres().then((data) => setGenreList(data)),
+      fetchPlatforms().then((data) => setPlatformList(data)),
+      fetchTags().then((data) => setTagList(data)),
     ]).finally(() => {
-      // 모든 패치 완료 후 페이지 표출위해 설정
       setIsInitialized(true);
     });
   }, [router]);
-
-  // 이름 → id 변환: available 목록에서 인덱스+1로 id 찾기
-  const toIds = (names: string[], availableList: string[]) =>
-    names.map((name) => availableList.indexOf(name) + 1).filter((id) => id > 0);
 
   const toggleSelection = (
     item: string,
@@ -113,9 +113,9 @@ export default function MyPage() {
   const handleSave = async () => {
     try {
       const updated = await putPreferences({
-        genre_ids: toIds(selectedGenres, availableGenres),
-        platform_ids: toIds(selectedPlatforms, availablePlatforms),
-        tag_ids: toIds(selectedThemes, availableThemes),
+        genre_ids: preferenceNamesToIds(selectedGenres, genreList),
+        platform_ids: preferenceNamesToIds(selectedPlatforms, platformList),
+        tag_ids: preferenceNamesToIds(selectedThemes, tagList),
       });
       setPreferences(updated);
       setIsModalOpen(false);

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -6,13 +6,12 @@ import { motion } from "motion/react";
 import { Check } from "lucide-react";
 import { getAccessToken } from "@/src/constants/auth";
 import { putPreferences, fetchPreferences } from "@/src/api/mypage";
+import { fetchGenres, fetchPlatforms, fetchTags } from "@/src/api/game";
+import type { GenreItem, PlatformItem, TagItem } from "@/src/api/game";
 import {
   getPreferenceSections,
   preferenceNamesToIds,
   togglePreferenceSelection,
-  availableGenres,
-  availablePlatforms,
-  availableThemes,
 } from "@/src/lib/preferences";
 import { AuthBackground } from "@/app/components/common/AuthBackground";
 import styles from "./page.module.scss";
@@ -25,18 +24,33 @@ export default function OnboardingPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [isReady, setIsReady] = useState(false);
 
+  // API에서 가져온 전체 목록 (id 포함)
+  const [genreList, setGenreList] = useState<GenreItem[]>([]);
+  const [platformList, setPlatformList] = useState<PlatformItem[]>([]);
+  const [tagList, setTagList] = useState<TagItem[]>([]);
+
   useEffect(() => {
     const token = getAccessToken();
     if (!token) {
       router.replace("/login");
       return;
     }
-    fetchPreferences()
-      .then((data) => {
-        if (data) {
-          setSelectedGenres(data.genres.map((g) => g.name));
-          setSelectedPlatforms(data.platforms.map((p) => p.name));
-          setSelectedThemes(data.tags.map((t) => t.name));
+
+    Promise.all([
+      fetchGenres(),
+      fetchPlatforms(),
+      fetchTags(),
+      fetchPreferences(),
+    ])
+      .then(([genres, platforms, tags, prefs]) => {
+        setGenreList(genres);
+        setPlatformList(platforms);
+        setTagList(tags);
+
+        if (prefs) {
+          setSelectedGenres(prefs.genres.map((g) => g.name));
+          setSelectedPlatforms(prefs.platforms.map((p) => p.name));
+          setSelectedThemes(prefs.tags.map((t) => t.name));
         }
       })
       .finally(() => setIsReady(true));
@@ -46,12 +60,9 @@ export default function OnboardingPage() {
     setIsSaving(true);
     try {
       await putPreferences({
-        genre_ids: preferenceNamesToIds(selectedGenres, availableGenres),
-        platform_ids: preferenceNamesToIds(
-          selectedPlatforms,
-          availablePlatforms
-        ),
-        tag_ids: preferenceNamesToIds(selectedThemes, availableThemes),
+        genre_ids: preferenceNamesToIds(selectedGenres, genreList),
+        platform_ids: preferenceNamesToIds(selectedPlatforms, platformList),
+        tag_ids: preferenceNamesToIds(selectedThemes, tagList),
       });
       router.push("/");
     } catch (err) {
@@ -75,6 +86,9 @@ export default function OnboardingPage() {
     setSelectedGenres,
     setSelectedPlatforms,
     setSelectedThemes,
+    availableGenres: genreList.map((g) => g.name),
+    availablePlatforms: platformList.map((p) => p.name),
+    availableThemes: tagList.map((t) => t.name),
   });
 
   return (

--- a/src/api/game.ts
+++ b/src/api/game.ts
@@ -133,6 +133,21 @@ export async function fetchSimilarGames(
   }));
 }
 
+// 장르 데이터 타입
+export interface GenreItem {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+// 전체 장르 목록 조회
+export async function fetchGenres(): Promise<GenreItem[]> {
+  const { data } = await apiClient.get<{ results: GenreItem[] }>(
+    "/api/v1/games/genres/"
+  );
+  return data.results || [];
+}
+
 // 플랫폼 데이터 타입
 export interface PlatformItem {
   id: number;
@@ -145,6 +160,20 @@ export interface PlatformItem {
 export async function fetchPlatforms(): Promise<PlatformItem[]> {
   const { data } = await apiClient.get<{ results: PlatformItem[] }>(
     "/api/v1/games/platforms/"
+  );
+  return data.results || [];
+}
+
+// 태그 데이터 타입
+export interface TagItem {
+  id: number;
+  name: string;
+}
+
+// 전체 태그 목록 조회
+export async function fetchTags(): Promise<TagItem[]> {
+  const { data } = await apiClient.get<{ results: TagItem[] }>(
+    "/api/v1/games/tags/"
   );
   return data.results || [];
 }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,18 +1,16 @@
 import type { LucideIcon } from "lucide-react";
 import { Gamepad2, Settings, Tag } from "lucide-react";
-import {
-  availableGenres,
-  availablePlatforms,
-  availableThemes,
-} from "@/src/mocks/data/preferences";
 
-/** 이름 배열 → id 배열 (available 목록 인덱스+1) */
+/** 이름 배열 → id 배열 (available 목록에서 이름이 일치하는 항목의 id 반환) */
 export function preferenceNamesToIds(
   names: string[],
-  availableList: string[]
+  availableList: { id: number; name: string }[]
 ): number[] {
   return names
-    .map((name) => availableList.indexOf(name) + 1)
+    .map((name) => {
+      const found = availableList.find((item) => item.name === name);
+      return found ? found.id : -1;
+    })
     .filter((id) => id > 0);
 }
 
@@ -45,30 +43,31 @@ export function getPreferenceSections(state: {
   setSelectedGenres: (v: string[]) => void;
   setSelectedPlatforms: (v: string[]) => void;
   setSelectedThemes: (v: string[]) => void;
+  availableGenres: string[];
+  availablePlatforms: string[];
+  availableThemes: string[];
 }): PreferenceSectionConfig[] {
   return [
     {
       title: "선호 장르",
       icon: Gamepad2,
-      items: availableGenres,
+      items: state.availableGenres,
       selected: state.selectedGenres,
       setSelected: state.setSelectedGenres,
     },
     {
       title: "선호 플랫폼",
       icon: Settings,
-      items: availablePlatforms,
+      items: state.availablePlatforms,
       selected: state.selectedPlatforms,
       setSelected: state.setSelectedPlatforms,
     },
     {
       title: "선호 테마",
       icon: Tag,
-      items: availableThemes,
+      items: state.availableThemes,
       selected: state.selectedThemes,
       setSelected: state.setSelectedThemes,
     },
   ];
 }
-
-export { availableGenres, availablePlatforms, availableThemes };


### PR DESCRIPTION
## 🩵PR 요약
- 나의 선호 장르,플랫폼,태그 리스트 api 연동

## 📌 관련 이슈
Closes #93

## 📄 상세 내용
- [ ] 나의 선호 장르,플랫폼,태그 리스트 api 연동

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료