### PR TITLE
[feat] OAuth 콜백·온보딩 HttpOnly 쿠키 대응 (#101)

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -2,32 +2,35 @@
 
 import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { setAccessToken } from "@/src/constants/auth";
 
 /**
- * OAuth 콜백 페이지 (카카오 등)
- * 백엔드가 인증 후 이 URL로 리다이렉트하며 access_token 또는 error를 쿼리로 전달
+ * OAuth 콜백 페이지 (카카오, 디스코드)
+ * - 백엔드 콜백: v1_auth_kakao_callback_retrieve, v1_auth_discord_callback_retrieve
+ * - 성공 시: is_new_user=true → /onboarding, is_new_user=false → /
+ * - 실패 시: error, error_description 쿼리
+ * - access_token/refresh_token은 HttpOnly 쿠키로 설정 (JS에서 접근 불가)
  */
 export default function AuthCallbackPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const accessToken =
-    searchParams.get("access_token") ?? searchParams.get("token");
+  const isNewUser = searchParams.get("is_new_user");
   const error = searchParams.get("error");
   const errorDesc = searchParams.get("error_description");
-  const nextUrl = searchParams.get("next") ?? "/";
 
   const errorMessage = error
     ? (errorDesc ?? error ?? "로그인에 실패했습니다. 다시 시도해 주세요.")
     : "유효하지 않은 접근입니다. 로그인 페이지로 이동합니다.";
 
-  const isError = !!error || !accessToken;
+  const isError = !!error || (isNewUser !== "true" && isNewUser !== "false");
 
   useEffect(() => {
-    if (accessToken) {
-      setAccessToken(accessToken);
-      router.replace(nextUrl);
+    if (isNewUser === "true") {
+      router.replace("/onboarding");
+      return;
+    }
+    if (isNewUser === "false") {
+      router.replace("/");
       return;
     }
 
@@ -35,7 +38,7 @@ export default function AuthCallbackPage() {
       const t = setTimeout(() => router.replace("/login"), 2000);
       return () => clearTimeout(t);
     }
-  }, [accessToken, error, nextUrl, router]);
+  }, [isNewUser, error, router]);
 
   if (!isError) {
     return (

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -4,8 +4,11 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "motion/react";
 import { Check } from "lucide-react";
-import { getAccessToken } from "@/src/constants/auth";
-import { putPreferences, fetchPreferences } from "@/src/api/mypage";
+import {
+  putPreferences,
+  fetchPreferences,
+  fetchUserProfile,
+} from "@/src/api/mypage";
 import { fetchGenres, fetchPlatforms, fetchTags } from "@/src/api/game";
 import type { GenreItem, PlatformItem, TagItem } from "@/src/api/game";
 import {
@@ -30,30 +33,33 @@ export default function OnboardingPage() {
   const [tagList, setTagList] = useState<TagItem[]>([]);
 
   useEffect(() => {
-    const token = getAccessToken();
-    if (!token) {
-      router.replace("/login");
-      return;
-    }
+    const init = async () => {
+      const profile = await fetchUserProfile();
+      if (!profile) {
+        router.replace("/login");
+        return;
+      }
 
-    Promise.all([
-      fetchGenres(),
-      fetchPlatforms(),
-      fetchTags(),
-      fetchPreferences(),
-    ])
-      .then(([genres, platforms, tags, prefs]) => {
-        setGenreList(genres);
-        setPlatformList(platforms);
-        setTagList(tags);
+      const [genres, platforms, tags, prefs] = await Promise.all([
+        fetchGenres(),
+        fetchPlatforms(),
+        fetchTags(),
+        fetchPreferences(),
+      ]);
 
-        if (prefs) {
-          setSelectedGenres(prefs.genres.map((g) => g.name));
-          setSelectedPlatforms(prefs.platforms.map((p) => p.name));
-          setSelectedThemes(prefs.tags.map((t) => t.name));
-        }
-      })
-      .finally(() => setIsReady(true));
+      setGenreList(genres);
+      setPlatformList(platforms);
+      setTagList(tags);
+
+      if (prefs) {
+        setSelectedGenres(prefs.genres.map((g) => g.name));
+        setSelectedPlatforms(prefs.platforms.map((p) => p.name));
+        setSelectedThemes(prefs.tags.map((t) => t.name));
+      }
+      setIsReady(true);
+    };
+
+    init();
   }, [router]);
 
   const handleSave = async () => {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -129,12 +129,19 @@ export async function requestPasswordReset(
   return data;
 }
 
-/** 소셜 로그인(카카오/디스코드) 리다이렉트 URL */
+/**
+ * 소셜 로그인(카카오/디스코드) 리다이렉트 URL
+ * - 카카오: GET /api/v1/auth/kakao/login/ (v1_auth_kakao_login_retrieve)
+ * - 디스코드: GET /api/v1/auth/discord/login/ (v1_auth_discord_login_retrieve)
+ * 백엔드가 OAuth 후 프론트엔드 /auth/callback으로 리다이렉트하며,
+ * access_token/refresh_token은 HttpOnly 쿠키로 설정됨.
+ */
 export function getOAuthLoginUrl(provider: "kakao" | "discord"): string {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
   const redirectUri =
     typeof window !== "undefined"
       ? `${window.location.origin}/auth/callback`
       : "/auth/callback";
-  return `${base}/api/v1/auth/${provider}/login/?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const params = new URLSearchParams({ redirect_uri: redirectUri });
+  return `${base}/api/v1/auth/${provider}/login/?${params.toString()}`;
 }


### PR DESCRIPTION
## 🩵 PR 요약
OAuth HttpOnly 쿠키 대응 및 콜백/온보딩 인증 로직 수정

## 📌 관련 이슈
Closes #101 

## 📄 상세 내용
- [x] OAuth 콜백: access_token 제거, is_new_user(true→/onboarding, false→/) 기준 리다이렉트
- [x] 온보딩: getAccessToken 대신 fetchUserProfile()로 인증 확인, 401 시 /login 리다이렉트
- [x] getOAuthLoginUrl: Swagger API 경로 기반, redirect_uri 파라미터 전달

## 💬 리뷰 포인트
authApiClient의 withCredentials: true 설정으로 쿠키 전송 여부 확인

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료