### PR TITLE
[feat] OAuth 쿠키 로그인 시 헤더·마이페이지 세션 반영 (#104)

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -54,19 +54,29 @@ export function Header() {
       removeAccessToken();
       window.history.replaceState({}, "", window.location.pathname);
     }
-    const hasToken = !!getAccessToken();
-    queueMicrotask(() => setIsLoggedIn(hasToken));
-  }, [pathname]);
 
-  useEffect(() => {
-    if (!isLoggedIn) {
+    let cancelled = false;
+    // 이메일 로그인: Bearer(sessionStorage) + OAuth: HttpOnly 쿠키만 — 둘 다 fetchUserProfile로 판별
+    void (async () => {
+      const profile = await fetchUserProfile();
+      if (cancelled) return;
+      if (profile) {
+        setIsLoggedIn(true);
+        setUserProfile(profile);
+        setProfileImgError(false);
+        return;
+      }
+      const token = getAccessToken();
+      if (token) removeAccessToken();
+      setIsLoggedIn(false);
       setUserProfile(null);
       setProfileImgError(false);
-      return;
-    }
-    setProfileImgError(false);
-    fetchUserProfile().then((profile) => setUserProfile(profile));
-  }, [isLoggedIn]);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -119,12 +129,13 @@ export function Header() {
   const handleLogout = async () => {
     const token = getAccessToken();
     try {
-      if (token) await logout(token);
+      await logout(token ?? undefined);
     } catch {
       // API 실패해도 로컬 로그아웃 진행
     } finally {
       removeAccessToken();
       setIsLoggedIn(false);
+      setUserProfile(null);
       setShowProfileMenu(false);
       router.push("/");
     }

--- a/app/components/mypage/ProfileHeader.tsx
+++ b/app/components/mypage/ProfileHeader.tsx
@@ -20,7 +20,7 @@ export function ProfileHeader({ nickname, email, bio }: ProfileHeaderProps) {
   const handleLogout = async () => {
     const token = getAccessToken();
     try {
-      if (token) await logout(token);
+      await logout(token ?? undefined);
     } catch {
       // API 실패해도 로컬 로그아웃 진행
     } finally {

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getAccessToken } from "@/src/constants/auth";
 import { ProfileHeader } from "@/app/components/mypage/ProfileHeader";
 import { StatsGrid } from "@/app/components/mypage/StatsGrid";
 import { GamePreferences } from "@/app/components/mypage/GamePreferences";
@@ -63,39 +62,39 @@ export default function MyPage() {
   const [platformList, setPlatformList] = useState<PlatformItem[]>([]);
   const [tagList, setTagList] = useState<TagItem[]>([]);
 
-  // 초기 상태 설정
+  // 초기 상태 설정 (이메일 Bearer + OAuth HttpOnly 쿠키 모두 fetchUserProfile로 판별)
   useEffect(() => {
-    const token = getAccessToken();
-    if (!token) {
-      router.replace("/login");
-      return;
-    }
+    const init = async () => {
+      const profileData = await fetchUserProfile();
+      if (!profileData) {
+        router.replace("/login");
+        return;
+      }
+      setProfile(profileData);
 
-    // 데이터 모두 로드
-    Promise.all([
-      fetchUserProfile().then((data) => {
-        if (data) setProfile(data);
-      }),
-      fetchPreferences().then((data) => {
-        if (data) {
-          setPreferences(data);
-          setSelectedGenres(data.genres.map((g) => g.name));
-          setSelectedPlatforms(data.platforms.map((p) => p.name));
-          setSelectedThemes(data.tags.map((t) => t.name));
-        }
-      }),
-      fetchSavedGames().then((data) => {
-        if (data) setWishlist(data);
-      }),
-      fetchRecommendedGames().then((data) => {
-        if (data) setRecommendedGames(data.results);
-      }),
-      fetchGenres().then((data) => setGenreList(data)),
-      fetchPlatforms().then((data) => setPlatformList(data)),
-      fetchTags().then((data) => setTagList(data)),
-    ]).finally(() => {
+      await Promise.all([
+        fetchPreferences().then((data) => {
+          if (data) {
+            setPreferences(data);
+            setSelectedGenres(data.genres.map((g) => g.name));
+            setSelectedPlatforms(data.platforms.map((p) => p.name));
+            setSelectedThemes(data.tags.map((t) => t.name));
+          }
+        }),
+        fetchSavedGames().then((data) => {
+          if (data) setWishlist(data);
+        }),
+        fetchRecommendedGames().then((data) => {
+          if (data) setRecommendedGames(data.results);
+        }),
+        fetchGenres().then((data) => setGenreList(data)),
+        fetchPlatforms().then((data) => setPlatformList(data)),
+        fetchTags().then((data) => setTagList(data)),
+      ]);
       setIsInitialized(true);
-    });
+    };
+
+    void init();
   }, [router]);
 
   const toggleSelection = (

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -46,15 +46,20 @@ export async function login(
   return data;
 }
 
-export async function logout(accessToken: string): Promise<LogoutResponse> {
+/** Bearer(이메일 로그인) 또는 HttpOnly 쿠키(OAuth)로 세션 종료 */
+export async function logout(
+  accessToken?: string | null
+): Promise<LogoutResponse> {
   const { data } = await authApiClient.post<LogoutResponse>(
     "/api/v1/auth/logout/",
     undefined,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
+    accessToken
+      ? {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      : undefined
   );
   return data;
 }


### PR DESCRIPTION
## 🩵 PR 요약
OAuth(HttpOnly 쿠키) 로그인 시 헤더·마이페이지에서 로그인 상태가 반영되도록 프로필 API 기반으로 세션 판별

## 📌 관련 이슈
Closes #104 

## 📄 상세 내용
- [x] Header: `fetchUserProfile()`로 로그인 여부·프로필 로드, 실패 시 sessionStorage 토큰 정리
- [x] mypage: `getAccessToken()` 게이트 제거 → `fetchUserProfile()` 없으면 `/login`
- [x] `logout(accessToken?)` — 토큰 없을 때 쿠키 기반 로그아웃
- [x] Header·ProfileHeader에서 `logout(token ?? undefined)` 호출

## 💬 리뷰 포인트
이메일 로그인(기존 Bearer + sessionStorage)과 OAuth(쿠키만) 모두 `authApiClient` + `fetchUserProfile` 경로로 맞는지

## 🧠 기타 참고사항
- `GameCard`·`edit-profile` 등 다른 `getAccessToken()` 사용처는 이번 PR 범위 밖일 수 있음
⭐️제가 맡은 페이지들 외엔 최대한 안 건드리려다보니 헤더에 로그인 상태 반영하는걸 놓쳤던 것 같습니다.

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료