### PR TITLE
[fix] CSRF 토큰 JSON 응답 처리 및 X-CSRFToken 전송 (#121)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import type { AuthMeResponse } from "@/src/api/auth";
 import { fetchAuthMe } from "@/src/api/auth";
 import { fetchUserProfile, type UserProfile } from "@/src/api/mypage";
 import { AUTH_INVALID_EVENT } from "@/src/lib/authEvents";
+import { clearCsrfTokenMemory } from "@/src/lib/api";
 
 type AuthContextValue = {
   /** GET /api/v1/auth/me/ 응답 */
@@ -63,6 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const clearAuth = useCallback(() => {
+    clearCsrfTokenMemory();
     setAuthUser(null);
     setProfile(null);
   }, []);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,25 +9,76 @@ const apiBaseURL =
 
 const unsafeMethods = new Set(["post", "put", "patch", "delete"]);
 
-const CSRF_PATH = "/api/v1/auth/csrf/";
+/** 스웨거/백엔드 경로와 맞출 것. 예: /api/v1/auth/csrf/ 또는 /auth/csrf/ */
+function getCsrfPath(): string {
+  const fromEnv = process.env.NEXT_PUBLIC_AUTH_CSRF_PATH?.trim();
+  if (fromEnv) {
+    return fromEnv.startsWith("/") ? fromEnv : `/${fromEnv}`;
+  }
+  return "/api/v1/auth/csrf/";
+}
 
 /**
- * Swagger: v1_auth_csrf_retrieve — csrftoken 쿠키 발급
- * fetch 사용: axios 인터셉터 순환 참조 방지
+ * GET /api/v1/auth/csrf/ 응답 본문에서 토큰 추출
+ * 스웨거 예: `{ "csrf_token": "..." }` — Set-Cookie 없이 JSON만 오는 경우 대비
  */
-async function ensureCsrfCookie(): Promise<void> {
-  if (typeof window === "undefined") return;
-  if (getCsrfTokenFromCookie()) return;
+let csrfTokenFromResponse: string | null = null;
 
-  const url = apiBaseURL
-    ? `${apiBaseURL.replace(/\/+$/, "")}${CSRF_PATH}`
-    : CSRF_PATH;
+function parseCsrfFromJson(data: unknown): string | null {
+  if (!data || typeof data !== "object") return null;
+  const o = data as Record<string, unknown>;
+  const keys = ["csrf_token", "csrfToken", "csrf", "token"] as const;
+  for (const k of keys) {
+    const v = o[k];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return null;
+}
+
+function getEffectiveCsrfToken(): string | null {
+  return csrfTokenFromResponse ?? getCsrfTokenFromCookie();
+}
+
+/** export: 로그아웃 후 등에서 메모리 토큰 초기화 */
+export function clearCsrfTokenMemory(): void {
+  csrfTokenFromResponse = null;
+}
+
+/**
+ * GET CSRF — 응답 JSON의 csrf_token을 메모리에 두고 X-CSRFToken에 사용
+ * (쿠키 없이 본문만 주는 백엔드 대응) fetch 사용: axios 인터셉터 순환 참조 방지
+ */
+async function ensureCsrfToken(): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (getEffectiveCsrfToken()) return;
+
+  const path = getCsrfPath();
+  const url = apiBaseURL ? `${apiBaseURL.replace(/\/+$/, "")}${path}` : path;
 
   try {
-    await fetch(url, { method: "GET", credentials: "include" });
+    const res = await fetch(url, { method: "GET", credentials: "include" });
+    const text = await res.text();
+    if (text) {
+      try {
+        const json = JSON.parse(text) as unknown;
+        const parsed = parseCsrfFromJson(json);
+        if (parsed) csrfTokenFromResponse = parsed;
+      } catch {
+        /* 본문이 JSON이 아닐 수 있음 */
+      }
+    }
+    if (!csrfTokenFromResponse) {
+      const fromCookie = getCsrfTokenFromCookie();
+      if (fromCookie) csrfTokenFromResponse = fromCookie;
+    }
   } catch {
     /* 네트워크 오류 시 이후 요청에서 재시도 */
   }
+}
+
+function isCsrfEndpointUrl(url: string): boolean {
+  const path = getCsrfPath();
+  return url.includes("csrf") || url.endsWith(path) || url.includes(path);
 }
 
 async function attachCsrf(config: InternalAxiosRequestConfig) {
@@ -37,10 +88,10 @@ async function attachCsrf(config: InternalAxiosRequestConfig) {
   const method = config.method?.toLowerCase();
   if (method && unsafeMethods.has(method)) {
     const url = config.url ?? "";
-    if (!url.includes("/api/v1/auth/csrf")) {
-      await ensureCsrfCookie();
+    if (!isCsrfEndpointUrl(url)) {
+      await ensureCsrfToken();
     }
-    const token = getCsrfTokenFromCookie();
+    const token = getEffectiveCsrfToken();
     if (token) {
       config.headers.set("X-CSRFToken", token);
     }
@@ -50,7 +101,8 @@ async function attachCsrf(config: InternalAxiosRequestConfig) {
 
 /** 앱에서 필요 시 명시 호출 (선택) */
 export async function fetchCsrfToken(): Promise<void> {
-  await ensureCsrfCookie();
+  csrfTokenFromResponse = null;
+  await ensureCsrfToken();
 }
 
 /** 세션 없을 때 401이 정상인 요청 — refresh 시도하지 않음 */

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -1,13 +1,22 @@
 /**
- * Django-style csrftoken 쿠키 읽기 (HttpOnly가 아닌 경우에만 동작)
+ * CSRF 쿠키 이름 후보 (백엔드/Django 설정에 따라 다름)
+ * HttpOnly 쿠키는 JS에서 읽을 수 없음 → GET /auth/csrf/ 응답 본문 토큰 필요
  */
+const CSRF_COOKIE_NAMES = ["csrftoken", "csrf_token", "csrfToken"] as const;
+
 export function getCsrfTokenFromCookie(): string | null {
   if (typeof document === "undefined") return null;
-  const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]*)/);
-  if (!match?.[1]) return null;
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return match[1];
+  for (const name of CSRF_COOKIE_NAMES) {
+    const match = document.cookie.match(
+      new RegExp(`(?:^|;\\s*)${name}=([^;]*)`)
+    );
+    if (match?.[1]) {
+      try {
+        return decodeURIComponent(match[1]);
+      } catch {
+        return match[1];
+      }
+    }
   }
+  return null;
 }


### PR DESCRIPTION
## 🩵 PR 요약
CSRF를 JSON 본문(`csrf_token`)에서 읽어 `X-CSRFToken`으로 전송하도록 수정

## 📌 관련 이슈
Closes #121 

## 📄 상세 내용
- [x] `ensureCsrfToken`: fetch 후 JSON 파싱, `csrf_token` 우선
- [x] `getEffectiveCsrfToken`: 메모리 토큰 + 쿠키(가능 시) 병용
- [x] `clearCsrfTokenMemory` + `AuthContext.clearAuth` 연동
- [x] 주석: 스웨거 응답 형태·Set-Cookie 없음 명시

## 💬 리뷰 포인트
- 배포 환경에서 CSRF 경로가 다르면 `NEXT_PUBLIC_AUTH_CSRF_PATH` 설정 필요 여부

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 console.log 제거
- [x] 로컬 빌드 확인