### PR TITLE
[feat] 회원탈퇴 API 연동·계정 삭제 UI·탈퇴 완료 페이지 (#127)

### DIFF
--- a/app/account-deleted/page.module.scss
+++ b/app/account-deleted/page.module.scss
@@ -1,0 +1,87 @@
+@use "../styles/variables" as *;
+@use "../styles/mixins" as *;
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  background: $black;
+}
+
+.card {
+  @include glass-card;
+  max-width: 26rem;
+  width: 100%;
+  padding: 2.5rem 2rem;
+  border-radius: 0.75rem;
+  text-align: center;
+}
+
+.iconWrap {
+  margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.icon {
+  width: 3rem;
+  height: 3rem;
+  color: rgba(228, 255, 48, 0.85);
+}
+
+.title {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: $white;
+  line-height: 1.35;
+}
+
+.lead {
+  margin: 0 0 1rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: $white-70;
+}
+
+.detail {
+  margin: 0 0 2rem;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: $white-50;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.primaryBtn {
+  @include btn-primary;
+  display: block;
+  padding: 0.75rem 1rem;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  font-weight: 600;
+}
+
+.secondaryBtn {
+  display: block;
+  padding: 0.75rem 1rem;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: background 0.2s;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}

--- a/app/account-deleted/page.tsx
+++ b/app/account-deleted/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "motion/react";
+import { Heart } from "lucide-react";
+import styles from "./page.module.scss";
+
+/**
+ * 회원 탈퇴 완료 후 감사 인사 — 토스트만으로는 정책·감정 전달이 부족해 별도 페이지로 둠
+ */
+export default function AccountDeletedPage() {
+  return (
+    <div className={styles.page}>
+      <motion.div
+        className={styles.card}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <div className={styles.iconWrap}>
+          <Heart
+            className={styles.icon}
+            fill="currentColor"
+            strokeWidth={1.5}
+            aria-hidden
+          />
+        </div>
+        <h1 className={styles.title}>그동안 이용해 주셔서 감사합니다</h1>
+        <p className={styles.lead}>
+          회원 탈퇴가 접수되었습니다. 계정은 일정 기간 후 영구 삭제되며, 그
+          전까지 복구할 수 있습니다.
+        </p>
+        <p className={styles.detail}>
+          탈퇴 후 7일 이내 복구가 가능하고, 7일 이후에는 동일 이메일로 새로
+          가입하게 됩니다.
+        </p>
+        <div className={styles.actions}>
+          <Link href="/" className={styles.primaryBtn}>
+            홈으로 가기
+          </Link>
+          <Link href="/login" className={styles.secondaryBtn}>
+            로그인 페이지
+          </Link>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/src/contexts/AuthContext";
+import { setLoginMethod } from "@/src/lib/loginMethod";
 
 /**
  * OAuth 콜백 — 쿠키는 백엔드가 설정. 프론트는 auth/me로 세션 복원 후 이동.
@@ -25,11 +26,13 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const run = async () => {
       if (isNewUser === "true") {
+        setLoginMethod("oauth");
         await refreshAuth();
         router.replace("/onboarding");
         return;
       }
       if (isNewUser === "false") {
+        setLoginMethod("oauth");
         await refreshAuth();
         router.replace("/");
         return;

--- a/app/components/edit-profile/AccountDeletionSection.module.scss
+++ b/app/components/edit-profile/AccountDeletionSection.module.scss
@@ -1,0 +1,80 @@
+@use "../../styles/variables" as *;
+@use "../../styles/mixins" as *;
+
+.section {
+  @include glass-card;
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  background: rgba(18, 18, 18, 0.95);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.warnIcon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: #f87171;
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: $white;
+}
+
+.body {
+  margin-bottom: 1.25rem;
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: $white-50;
+
+  p {
+    margin: 0 0 0.75rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  strong {
+    color: rgba(255, 255, 255, 0.85);
+    font-weight: 600;
+  }
+}
+
+.code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.dangerBtn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  background: rgba(127, 29, 29, 0.5);
+  color: #fca5a5;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+
+  &:hover {
+    background: rgba(153, 27, 27, 0.65);
+    border-color: rgba(239, 68, 68, 0.65);
+  }
+}

--- a/app/components/edit-profile/AccountDeletionSection.tsx
+++ b/app/components/edit-profile/AccountDeletionSection.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import { getApiErrorMessage } from "@/src/api/mypage";
+import { DeleteAccountModal } from "./DeleteAccountModal";
+import styles from "./AccountDeletionSection.module.scss";
+
+type AccountDeletionSectionProps = {
+  onDeleteConfirmed: () => Promise<void>;
+};
+
+export function AccountDeletionSection({
+  onDeleteConfirmed,
+}: AccountDeletionSectionProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setError(null);
+    setIsDeleting(true);
+    try {
+      await onDeleteConfirmed();
+    } catch (err) {
+      setError(getApiErrorMessage(err));
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <section
+        className={styles.section}
+        aria-labelledby="account-delete-heading"
+      >
+        <div className={styles.sectionHeader}>
+          <AlertTriangle
+            className={styles.warnIcon}
+            aria-hidden
+            strokeWidth={2}
+          />
+          <h2 id="account-delete-heading" className={styles.title}>
+            계정 삭제
+          </h2>
+        </div>
+        <div className={styles.body}>
+          <p>
+            회원님의 계정은 <strong>7일 후</strong> 영구 삭제됩니다. 탈퇴 시
+            개인정보·이용 기록 등은 서비스 정책에 따라 처리됩니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={styles.dangerBtn}
+          onClick={() => {
+            setError(null);
+            setModalOpen(true);
+          }}
+        >
+          계정 삭제
+        </button>
+      </section>
+
+      <DeleteAccountModal
+        open={modalOpen}
+        onClose={() => {
+          if (!isDeleting) setModalOpen(false);
+        }}
+        onConfirm={handleConfirm}
+        isDeleting={isDeleting}
+        error={error}
+      />
+    </>
+  );
+}

--- a/app/components/edit-profile/DeleteAccountModal.module.scss
+++ b/app/components/edit-profile/DeleteAccountModal.module.scss
@@ -1,0 +1,92 @@
+@use "../../styles/variables" as *;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  width: 100%;
+  max-width: 22rem;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: #121212;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+}
+
+.modalTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: $white;
+}
+
+.modalBody {
+  margin: 0 0 1.25rem;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: $white-50;
+}
+
+.modalError {
+  margin: 0 0 1rem;
+  font-size: 0.8125rem;
+  color: #f87171;
+}
+
+.modalActions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.cancelBtn {
+  flex: 1;
+  padding: 0.65rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.confirmBtn {
+  flex: 1;
+  padding: 0.65rem 1rem;
+  border-radius: 0.5rem;
+  border: none;
+  background: rgba(127, 29, 29, 0.85);
+  color: #fecaca;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover:not(:disabled) {
+    background: rgba(153, 27, 27, 0.95);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/app/components/edit-profile/DeleteAccountModal.tsx
+++ b/app/components/edit-profile/DeleteAccountModal.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import styles from "./DeleteAccountModal.module.scss";
+
+type DeleteAccountModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+  error?: string | null;
+};
+
+export function DeleteAccountModal({
+  open,
+  onClose,
+  onConfirm,
+  isDeleting,
+  error,
+}: DeleteAccountModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div
+          ref={overlayRef}
+          className={styles.overlay}
+          role="presentation"
+          onClick={(e) => {
+            if (e.target === overlayRef.current && !isDeleting) onClose();
+          }}
+        >
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-account-title"
+            className={styles.modal}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={{ duration: 0.2 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="delete-account-title" className={styles.modalTitle}>
+              정말 탈퇴하시겠어요?
+            </h2>
+            <p className={styles.modalBody}>
+              탈퇴가 접수되면 7일 이내에만 복구할 수 있고, 그 이후에는 영구
+              삭제되어 되돌릴 수 없습니다. 계속 진행할까요?
+            </p>
+            {error && <p className={styles.modalError}>{error}</p>}
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.cancelBtn}
+                onClick={onClose}
+                disabled={isDeleting}
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                className={styles.confirmBtn}
+                onClick={onConfirm}
+                disabled={isDeleting}
+              >
+                {isDeleting ? "처리 중..." : "네, 탈퇴합니다"}
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/components/edit-profile/EditProfileForm.tsx
+++ b/app/components/edit-profile/EditProfileForm.tsx
@@ -19,6 +19,8 @@ interface EditProfileFormProps {
   formData: EditFormData;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (e: React.FormEvent) => void;
+  /** 소셜 로그인 등 비밀번호 없음 — 비밀번호 변경 블록 숨김 */
+  hidePasswordChange?: boolean;
   profileImgUrl?: string | null;
   onImageChange?: (file: File) => void;
   onImageDelete?: () => void;
@@ -41,6 +43,7 @@ export function EditProfileForm({
   formData,
   onChange,
   onSubmit,
+  hidePasswordChange = false,
   profileImgUrl,
   onImageChange,
   onImageDelete,
@@ -175,33 +178,44 @@ export function EditProfileForm({
           </div>
         </div>
 
-        <div className={styles.divider} />
+        {!hidePasswordChange && (
+          <>
+            <div className={styles.divider} />
 
-        <div className={styles.pwSection}>
-          <h2 className={styles.sectionTitle}>비밀번호 변경</h2>
-          <p className={styles.hint}>
-            비밀번호를 변경하지 않으려면 아래 필드를 비워두세요
-          </p>
+            <div className={styles.pwSection}>
+              <h2 className={styles.sectionTitle}>비밀번호 변경</h2>
+              <p className={styles.hint}>
+                비밀번호를 변경하지 않으려면 아래 필드를 비워두세요
+              </p>
 
-          {passwordFields.map(({ label, name, placeholder }) => (
-            <div key={name}>
-              <label className={styles.label}>{label}</label>
-              <div className={styles.inputWrap}>
-                <div className={styles.inputIcon}>
-                  <Lock style={{ width: "1.25rem", height: "1.25rem" }} />
+              {passwordFields.map(({ label, name, placeholder }) => (
+                <div key={name}>
+                  <label className={styles.label}>{label}</label>
+                  <div className={styles.inputWrap}>
+                    <div className={styles.inputIcon}>
+                      <Lock style={{ width: "1.25rem", height: "1.25rem" }} />
+                    </div>
+                    <input
+                      type="password"
+                      name={name}
+                      value={formData[name]}
+                      onChange={onChange}
+                      placeholder={placeholder}
+                      className={styles.input}
+                    />
+                  </div>
                 </div>
-                <input
-                  type="password"
-                  name={name}
-                  value={formData[name]}
-                  onChange={onChange}
-                  placeholder={placeholder}
-                  className={styles.input}
-                />
-              </div>
+              ))}
             </div>
-          ))}
-        </div>
+          </>
+        )}
+
+        {hidePasswordChange && (
+          <p className={styles.hint} style={{ marginTop: "1rem" }}>
+            소셜 로그인으로 가입한 계정은 비밀번호가 없습니다.
+            닉네임·생일·프로필 사진만 수정할 수 있어요.
+          </p>
+        )}
 
         <div className={styles.actions}>
           <motion.button

--- a/app/edit-profile/page.tsx
+++ b/app/edit-profile/page.tsx
@@ -13,15 +13,20 @@ import {
   deleteProfileImage,
   verifyCurrentPassword,
   patchUserProfile,
+  shouldSkipPasswordVerification,
+  deleteAccount,
 } from "@/src/api/mypage";
+import { AccountDeletionSection } from "@/app/components/edit-profile/AccountDeletionSection";
 import { useAuth } from "@/src/contexts/AuthContext";
 import styles from "./page.module.scss";
 
 export default function EditProfilePage() {
   const router = useRouter();
-  const { isLoggedIn, isAuthLoading, refreshAuth } = useAuth();
+  const { isLoggedIn, isAuthLoading, refreshAuth, clearAuth } = useAuth();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [step, setStep] = useState<"password" | "edit">("password");
+  const [gateReady, setGateReady] = useState(false);
+  const [hidePasswordChange, setHidePasswordChange] = useState(false);
   const [currentPassword, setCurrentPassword] = useState("");
   const [formData, setFormData] = useState({
     currentPasswordEdit: "",
@@ -53,7 +58,13 @@ export default function EditProfilePage() {
           birth_date: data.birth_date || "",
         }));
         setProfileImgUrl(data.profile_img_url || null);
+        const skip = shouldSkipPasswordVerification(data);
+        setHidePasswordChange(skip);
+        if (skip) {
+          setStep("edit");
+        }
       }
+      setGateReady(true);
     });
   }, [router, isLoggedIn, isAuthLoading]);
 
@@ -141,7 +152,23 @@ export default function EditProfilePage() {
     }
   };
 
+  const handleAccountDelete = async () => {
+    await deleteAccount();
+    clearAuth();
+    router.push("/account-deleted");
+  };
+
   if (!isAuthenticated) return null;
+
+  if (!gateReady) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.inner}>
+          <p style={{ color: "rgba(255,255,255,0.75)" }}>불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.page}>
@@ -175,21 +202,25 @@ export default function EditProfilePage() {
             isLoading={isVerifying}
           />
         ) : (
-          <EditProfileForm
-            formData={formData}
-            onChange={handleChange}
-            onSubmit={handleSubmit}
-            profileImgUrl={profileImgUrl}
-            onImageChange={(file) => {
-              setSelectedImageFile(file);
-              setIsImageDeleted(false);
-            }}
-            onImageDelete={() => {
-              setSelectedImageFile(null);
-              setProfileImgUrl(null);
-              setIsImageDeleted(true);
-            }}
-          />
+          <>
+            <EditProfileForm
+              formData={formData}
+              onChange={handleChange}
+              onSubmit={handleSubmit}
+              hidePasswordChange={hidePasswordChange}
+              profileImgUrl={profileImgUrl}
+              onImageChange={(file) => {
+                setSelectedImageFile(file);
+                setIsImageDeleted(false);
+              }}
+              onImageDelete={() => {
+                setSelectedImageFile(null);
+                setProfileImgUrl(null);
+                setIsImageDeleted(true);
+              }}
+            />
+            <AccountDeletionSection onDeleteConfirmed={handleAccountDelete} />
+          </>
         )}
       </div>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,6 +7,7 @@ import { LoginLogo } from "@/app/components/login/LoginLogo";
 import { LoginForm } from "@/app/components/login/LoginForm";
 import { login } from "@/src/api/auth";
 import { useAuth } from "@/src/contexts/AuthContext";
+import { setLoginMethod } from "@/src/lib/loginMethod";
 import { AxiosError } from "axios";
 import styles from "./page.module.scss";
 
@@ -25,6 +26,7 @@ export default function LoginPage() {
 
     try {
       await login(email, password);
+      setLoginMethod("email");
       await refreshAuth();
       router.push("/");
     } catch (err) {

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -7,6 +7,7 @@ import { SignupLogo } from "@/app/components/signup/SignupLogo";
 import { SignupForm } from "@/app/components/signup/SignupForm";
 import { sendEmailVerificationCode, signup, login } from "@/src/api/auth";
 import { useAuth } from "@/src/contexts/AuthContext";
+import { setLoginMethod } from "@/src/lib/loginMethod";
 import { AxiosError } from "axios";
 import styles from "./page.module.scss";
 
@@ -86,6 +87,7 @@ export default function SignupPage() {
         birth_date: formData.birth_date,
       });
       await login(email.trim(), formData.password);
+      setLoginMethod("email");
       await refreshAuth();
       router.push("/onboarding");
     } catch (err) {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,21 @@
-import { authApiClient } from "@/src/lib/api";
+import {
+  authApiClient,
+  fetchCsrfToken,
+  getCsrfTokenForHeaders,
+} from "@/src/lib/api";
 
 /** Swagger: v1_auth_csrf_retrieve — CSRF 쿠키 선발급 (인터셉터에서도 자동 호출) */
 export { fetchCsrfToken } from "@/src/lib/api";
+
+async function requireCsrfBeforeUnsafeRequest(): Promise<void> {
+  await fetchCsrfToken();
+  const token = await getCsrfTokenForHeaders();
+  if (!token) {
+    throw new Error(
+      "보안 토큰(CSRF)을 받지 못했습니다. NEXT_PUBLIC_API_BASE_URL·MOCKING 설정과 네트워크를 확인해 주세요."
+    );
+  }
+}
 
 export interface LoginRequest {
   email: string;
@@ -57,6 +71,7 @@ export async function login(
   email: string,
   password: string
 ): Promise<LoginSuccessResponse | void> {
+  await requireCsrfBeforeUnsafeRequest();
   const { data } = await authApiClient.post<LoginSuccessResponse>(
     "/api/v1/auth/login/",
     { email, password }
@@ -66,6 +81,7 @@ export async function login(
 
 /** v1_auth_logout_create — POST /api/v1/auth/logout/ */
 export async function logout(): Promise<LogoutResponse> {
+  await requireCsrfBeforeUnsafeRequest();
   const { data } = await authApiClient.post<LogoutResponse>(
     "/api/v1/auth/logout/"
   );

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,4 +1,6 @@
+import type { AxiosError } from "axios";
 import { authApiClient } from "@/src/lib/api";
+import { getLoginMethod } from "@/src/lib/loginMethod";
 
 /** GET /api/v1/users/me/ - API 명세 UserMeResponse와 동일 */
 export interface UserProfile {
@@ -11,6 +13,27 @@ export interface UserProfile {
   adult_verified_at: string | null;
   is_active: boolean;
   created_at: string;
+  /** false면 소셜 전용 등 비밀번호 없음 — 프로필 수정 시 현재 비밀번호 확인 생략 */
+  has_usable_password?: boolean;
+  /** 예: kakao, discord, email — 백엔드 명세에 맞게 */
+  auth_provider?: string | null;
+}
+
+/**
+ * 소셜 전용(비밀번호 없음)이면 프로필 수정 전 비밀번호 확인 단계 생략
+ * - API: has_usable_password / auth_provider 우선
+ * - 없으면 마지막 로그인 방식(localStorage)으로 추정
+ */
+export function shouldSkipPasswordVerification(
+  profile: UserProfile | null
+): boolean {
+  if (!profile) return false;
+  if (profile.has_usable_password === true) return false;
+  if (profile.has_usable_password === false) return true;
+  const prov = profile.auth_provider?.toLowerCase();
+  if (prov === "kakao" || prov === "discord") return true;
+  if (getLoginMethod() === "oauth") return true;
+  return false;
 }
 
 export async function fetchUserProfile(): Promise<UserProfile | null> {
@@ -52,6 +75,45 @@ export async function patchUserProfile(
   } catch {
     return false;
   }
+}
+
+/**
+ * Swagger: `v1_users_me_destroy` — DELETE `/api/v1/users/me/`
+ * HttpOnly access_token 쿠키 + unsafe 요청 시 `X-CSRFToken` (authApiClient 인터셉터)
+ * @see https://d2c8om11rax5nb.cloudfront.net/api/schema/swagger-ui/#/Users/v1_users_me_destroy
+ */
+export interface DeleteAccountSuccessResponse {
+  message: string;
+}
+
+/** 401 UNAUTHORIZED / ACCOUNT_DEACTIVATED, 403 CSRF_FAILED 등 */
+export interface ApiStandardErrorBody {
+  status_code?: number;
+  code?: string;
+  message?: string;
+}
+
+export async function deleteAccount(): Promise<DeleteAccountSuccessResponse> {
+  const { data } =
+    await authApiClient.delete<DeleteAccountSuccessResponse>(
+      "/api/v1/users/me/"
+    );
+  return data ?? { message: "" };
+}
+
+/** Axios 응답 — `message`(명세) 또는 DRF `detail` */
+export function getApiErrorMessage(err: unknown): string {
+  const ax = err as AxiosError<
+    ApiStandardErrorBody & { detail?: string | string[] }
+  >;
+  const d = ax.response?.data;
+  if (d && typeof d === "object") {
+    if (typeof d.message === "string" && d.message.trim()) return d.message;
+    if (typeof d.detail === "string") return d.detail;
+    if (Array.isArray(d.detail)) return d.detail.map(String).join(" ");
+  }
+  if (ax.message) return ax.message;
+  return "요청에 실패했습니다.";
 }
 
 export interface PreferencesBody {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ import { fetchAuthMe } from "@/src/api/auth";
 import { fetchUserProfile, type UserProfile } from "@/src/api/mypage";
 import { AUTH_INVALID_EVENT } from "@/src/lib/authEvents";
 import { clearCsrfTokenMemory } from "@/src/lib/api";
+import { clearLoginMethod } from "@/src/lib/loginMethod";
 
 type AuthContextValue = {
   /** GET /api/v1/auth/me/ 응답 */
@@ -65,6 +66,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const clearAuth = useCallback(() => {
     clearCsrfTokenMemory();
+    clearLoginMethod();
     setAuthUser(null);
     setProfile(null);
   }, []);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios, { type InternalAxiosRequestConfig } from "axios";
+import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from "axios";
 import { getCsrfTokenFromCookie } from "@/src/lib/csrf";
 import { emitAuthInvalid } from "@/src/lib/authEvents";
 
@@ -35,6 +35,7 @@ function parseCsrfFromJson(data: unknown): string | null {
   return null;
 }
 
+/** 인터셉터용: 메모리(JSON) 또는 읽을 수 있는 쿠키 */
 function getEffectiveCsrfToken(): string | null {
   return csrfTokenFromResponse ?? getCsrfTokenFromCookie();
 }
@@ -45,24 +46,34 @@ export function clearCsrfTokenMemory(): void {
 }
 
 /**
- * GET CSRF — 응답 JSON의 csrf_token을 메모리에 두고 X-CSRFToken에 사용
- * (쿠키 없이 본문만 주는 백엔드 대응) fetch 사용: axios 인터셉터 순환 참조 방지
+ * GET /api/v1/auth/csrf/ 로 토큰 확보
+ * @param force true면 메모리만 비우고 쿠키로 조기 종료하지 않음 — 로그인/로그아웃 직전 갱신용
  */
-async function ensureCsrfToken(): Promise<void> {
+async function ensureCsrfToken(force = false): Promise<void> {
   if (typeof window === "undefined") return;
-  if (getEffectiveCsrfToken()) return;
+  if (!force && csrfTokenFromResponse) return;
 
   const path = getCsrfPath();
   const url = apiBaseURL ? `${apiBaseURL.replace(/\/+$/, "")}${path}` : path;
 
   try {
-    const res = await fetch(url, { method: "GET", credentials: "include" });
+    const res = await fetch(url, {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      return;
+    }
     const text = await res.text();
     if (text) {
       try {
         const json = JSON.parse(text) as unknown;
         const parsed = parseCsrfFromJson(json);
-        if (parsed) csrfTokenFromResponse = parsed;
+        if (parsed) {
+          csrfTokenFromResponse = parsed;
+          return;
+        }
       } catch {
         /* 본문이 JSON이 아닐 수 있음 */
       }
@@ -81,28 +92,45 @@ function isCsrfEndpointUrl(url: string): boolean {
   return url.includes("csrf") || url.endsWith(path) || url.includes(path);
 }
 
+function setCsrfHeader(
+  config: InternalAxiosRequestConfig,
+  token: string
+): void {
+  const h = AxiosHeaders.from(config.headers ?? {});
+  h.set("X-CSRFToken", token);
+  config.headers = h;
+}
+
 async function attachCsrf(config: InternalAxiosRequestConfig) {
   if (config.data instanceof FormData) {
-    config.headers.delete("Content-Type");
+    const h = AxiosHeaders.from(config.headers ?? {});
+    h.delete("Content-Type");
+    config.headers = h;
   }
   const method = config.method?.toLowerCase();
   if (method && unsafeMethods.has(method)) {
     const url = config.url ?? "";
     if (!isCsrfEndpointUrl(url)) {
-      await ensureCsrfToken();
+      await ensureCsrfToken(false);
     }
     const token = getEffectiveCsrfToken();
     if (token) {
-      config.headers.set("X-CSRFToken", token);
+      setCsrfHeader(config, token);
     }
   }
   return config;
 }
 
-/** 앱에서 필요 시 명시 호출 (선택) */
+/** 메모리 초기화 후 GET CSRF 강제 — 로그인/로그아웃 직전 */
 export async function fetchCsrfToken(): Promise<void> {
   csrfTokenFromResponse = null;
-  await ensureCsrfToken();
+  await ensureCsrfToken(true);
+}
+
+/** 인터셉터 외에서 직접 헤더를 붙일 때 토큰 문자열 */
+export async function getCsrfTokenForHeaders(): Promise<string | null> {
+  await ensureCsrfToken(false);
+  return getEffectiveCsrfToken();
 }
 
 /** 세션 없을 때 401이 정상인 요청 — refresh 시도하지 않음 */

--- a/src/lib/loginMethod.ts
+++ b/src/lib/loginMethod.ts
@@ -1,0 +1,36 @@
+/**
+ * 이메일 로그인 vs 소셜(OAuth) 로그인 구분 — 프로필 수정 시 비밀번호 확인 게이트 분기용
+ * 백엔드가 has_usable_password 등을 주면 그쪽을 우선한다.
+ */
+const STORAGE_KEY = "gechu_login_method";
+
+export type StoredLoginMethod = "email" | "oauth";
+
+export function setLoginMethod(method: StoredLoginMethod): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, method);
+  } catch {
+    /* private mode 등 */
+  }
+}
+
+export function getLoginMethod(): StoredLoginMethod | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v === "email" || v === "oauth") return v;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLoginMethod(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* */
+  }
+}


### PR DESCRIPTION
## 🩵PR 요약
- CSRF·쿠키 인증 흐름 보강, 소셜 사용자 내정보 수정 분기, 회원탈퇴 UI·API 연동 및 탈퇴 완료 페이지 추가

## 📌 관련 이슈
Closes #127

## 📄 상세 내용
- [x] `authApiClient`·`fetchCsrfToken` 등으로 GET CSRF 후 unsafe 요청에 `X-CSRFToken` 부착, 로그인/로그아웃 전 CSRF 확보
- [x] `loginMethod`로 이메일/소셜 구분 저장, 로그아웃 시 초기화
- [x] 소셜 사용자는 내정보 수정 시 비밀번호 확인 단계 생략·비밀번호 변경 블록 숨김
- [x] `DELETE /api/v1/users/me/` 탈퇴 API·에러 본문(`message`/`detail`) 파싱, 탈퇴 안내·확인 모달·`/account-deleted` 감사 페이지

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
- 내정보 수정(소셜) / 계정 삭제 섹션·모달 / 탈퇴 완료 페이지

## 🧠 기타 참고사항

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료